### PR TITLE
Compiler: log reflection type load exceptions

### DIFF
--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -3509,8 +3509,19 @@ namespace PascalABCCompiler
 
                 return cu;
             }
+            catch (ReflectionTypeLoadException e)
+            {
+                Console.Error.WriteLine(e.Message);
+                foreach (var eLoaderException in e.LoaderExceptions)
+                {
+                    Console.Error.WriteLine(eLoaderException.Message);
+                }
+
+                return null;
+            }
             catch (Exception e)
             {
+                Console.Error.WriteLine(e.Message);
                 return null;
             }
 		}


### PR DESCRIPTION
При использовании NuGet-пакетов, подключаемых через директиву компилятора `$reference`, очень часто возникают ошибки загрузки транзитивных сборок, которые совершенно невозможно отладить без логирования в указанных местах.

Например, если я пытаюсь сделать `{$reference ./packages/System.Reactive.Core/lib/net45/System.Reactive.Core.dll}`, при компиляции вылетает ошибка:

```
[0][1,3] Program.pas: Error by reading assembly './packages/System.Reactive.Core/lib/net45/System.Reactive.Core.dll'
````

Из такой ошибки непонятно, что происходит на самом деле. После патча эта ошибка аннотируется следующими сообщениями:

```
System.Reflection.ReflectionTypeLoadException: Не удается загрузить один или более запрошенных типов. Обратитесь к свойству LoaderExceptions для получения дополнительных сведений.
Не удалось загрузить файл или сборку "System.Reactive.Interfaces, Version=3.1.1.0, Culture=neutral, PublicKeyToken=xxxx" либо одну из их зависимостей. Не удается найти указанный файл.
[0][1,3] Program.pas: Error by reading assembly './packages/System.Reactive.Core/lib/net45/System.Reactive.Core.dll
```

Из этих сообщений уже становится понятно, что `System.Reactive.Core` зависит от `System.Reactive.Interfaces`, и этот пакет тоже нужно компилятору предоставить.