### PR TITLE
pabcnetcclear output executable name

### DIFF
--- a/pabcnetc_clear/ConsoleCompiler.cs
+++ b/pabcnetc_clear/ConsoleCompiler.cs
@@ -46,15 +46,12 @@ namespace PascalABCCompiler
 
             name = null;
             value = null;
-            var ss = directive.Split(':');
-            if (ss.Length>2)
-            {
-                Console.WriteLine("Directive can contain only one ':' sign");
-                return false;
-            }
+            var ss = directive.Split( new[]{':'}, 2);
             name = ss[0].ToLower();
             if (ss.Length > 1)
-                value = ss[1].ToLower();
+            {
+                value = ss[1].Trim().ToLower();
+            }
 
             return true;
         }
@@ -77,6 +74,9 @@ namespace PascalABCCompiler
                             Console.WriteLine("Bad value in 'Debug' directive '{0}'. Acceptable values are 0 or 1", value);
                             return false;
                     }
+                    case "output":
+                        co.OutputFileName = value;
+                        return true;
                 default:
                     Console.WriteLine("No such directive name: '{0}'", name);
                     return false;
@@ -98,7 +98,8 @@ namespace PascalABCCompiler
         {
             Console.WriteLine("Command line: ");
             Console.WriteLine("pabcnetcclear /directive1:value1 /directive2:value2 ... [inputfile]\n");
-            Console.WriteLine("Available directives:\n  /Help  /H  /?\n  /Debug:0(1)\n");
+            Console.WriteLine("Available directives:\n  /Help  /H  /?\n  /Debug:0(1) /output:[executable name]\n");
+            Console.WriteLine("/output:[executable name] Sets name of result executable");
             Console.WriteLine("/Debug:0 generates code with all .NET optimizations!");
         }
 

--- a/pabcnetc_clear/ConsoleCompiler.cs
+++ b/pabcnetc_clear/ConsoleCompiler.cs
@@ -103,7 +103,7 @@ namespace PascalABCCompiler
             Console.WriteLine("Command line: ");
             Console.WriteLine("pabcnetcclear /directive1:value1 /directive2:value2 ... [inputfile]\n");
             Console.WriteLine("Available directives:\n  /Help  /H  /?\n  /Debug:0(1) /output:[executable name]\n");
-            Console.WriteLine("/output:[executable name] Sets name of result executable");
+            Console.WriteLine("/output:[ <path>\\name ] Compile into an executable called \"name\" and save it in \"path\" directory");
             Console.WriteLine("/Debug:0 generates code with all .NET optimizations!");
         }
 

--- a/pabcnetc_clear/ConsoleCompiler.cs
+++ b/pabcnetc_clear/ConsoleCompiler.cs
@@ -102,8 +102,8 @@ namespace PascalABCCompiler
         {
             Console.WriteLine("Command line: ");
             Console.WriteLine("pabcnetcclear /directive1:value1 /directive2:value2 ... [inputfile]\n");
-            Console.WriteLine("Available directives:\n  /Help  /H  /?\n  /Debug:0(1) /output:[executable name]\n");
-            Console.WriteLine("/output:[ <path>\\name ] Compile into an executable called \"name\" and save it in \"path\" directory");
+            Console.WriteLine("Available directives:\n  /Help  /H  /?\n  /Debug:0(1)\n  /output:[<path>\\name]\n");
+            Console.WriteLine("/output:[ <path>\\name ] compile into an executable called \"name\" and save it in \"path\" directory");
             Console.WriteLine("/Debug:0 generates code with all .NET optimizations!");
         }
 

--- a/pabcnetc_clear/ConsoleCompiler.cs
+++ b/pabcnetc_clear/ConsoleCompiler.cs
@@ -75,7 +75,11 @@ namespace PascalABCCompiler
                             return false;
                     }
                     case "output":
-                        co.OutputFileName = value;
+                        co.OutputFileName = Path.GetFileName(value);
+                        if (Path.IsPathRooted(value))
+                        {
+                            co.OutputDirectory = Path.GetDirectoryName(value);
+                        }
                         return true;
                 default:
                     Console.WriteLine("No such directive name: '{0}'", name);


### PR DESCRIPTION
Здравствуйте!
Во-первых,  хочу выразить свое уважение за этот проект. Даже в свои школьные годы я прочувствовал разницу между PascalABCNet и каким-нибудь Free Pascal.

Сейчас я разрабатываю местную систему тестирования, на которой проводятся серьезные региональные олимпиады. 
В ней мы используем голый pabcnetcclear.  Почти у всех используемых нами компиляторов  есть опция, позволяющая задать имя екзешника, который получается в результате компиляции. Для упрощения нашей жизни, хотелось бы чтобы и pabcnetcclear такая опция присутствовала.

Собственно, в этом пулреквесте она и реализована

