### PR TITLE
Адекватная подсветка форматных строк

### DIFF
--- a/bin/Highlighting/PascalABCNET.xshd
+++ b/bin/Highlighting/PascalABCNET.xshd
@@ -2,7 +2,7 @@
 <!-- syntaxdefinition for PascalABC.NET (c) Ivan Bondarev, Stanislav Mikhalkovich -->
 
 <SyntaxDefinition name = "PascalABC.NET" extensions = ".pas;.paspart_">
-
+	
 	<Properties>
 		<Property name="LineComment" value="//"/>
 	</Properties>
@@ -44,6 +44,11 @@
 		  	
 			<Span name = "String" bold = "false" italic = "false" color = "Blue" stopateol = "true">
 				<Begin>'</Begin>
+				<End>'</End>
+			</Span>
+		  	
+			<Span name = "InterpolatedString" rule = "StringInterpolation" bold = "false" italic = "false" color = "Blue" stopateol = "true">
+				<Begin>$'</Begin>
 				<End>'</End>
 			</Span>
 			
@@ -302,7 +307,17 @@
 			<Key word = "true" />
 	  	</KeyWords>
 	</RuleSet>
-		
+	
+	<RuleSet name = "StringInterpolation" ignorecase = "true">
+		<Span name = "String" rule="Default" bold = "false" italic = "false" color = "Black" stopateol = "true">
+			<Begin>{</Begin>
+			<End>}</End>
+		</Span>
+	</RuleSet>
+	
+	<RuleSet name = "Default" ignorecase = "true" reference="PascalABC.NET">
+			<Delimiters>&lt;&gt;~!%^*()-+=|\#/{}[]:;"' ,	.?</Delimiters>
+	</RuleSet>
 
 		
 	</RuleSets>


### PR DESCRIPTION
Было:

![1](https://user-images.githubusercontent.com/44296606/80985001-4af2e800-8e37-11ea-822c-97a39c76bf68.png)

Стало:

![2](https://user-images.githubusercontent.com/44296606/80985013-4e866f00-8e37-11ea-8ea3-672eb09f567c.png)

Нормально подсвечиваются и операторы:

![3](https://user-images.githubusercontent.com/44296606/80985049-5b0ac780-8e37-11ea-90bf-121eab0cd1e5.png)

Единственный минус в том, что цифры внутри фигурных скобочек будут черными, потому что нет возможности указать цвет цифр внутри RuleSet'а. Но это небольшая потеря, учитывая насколько интерполированные строки теперь читабельнее.
