### PR TITLE
Исправление #2440

### DIFF
--- a/TestSuite/partial_constructor3.pas
+++ b/TestSuite/partial_constructor3.pas
@@ -1,0 +1,21 @@
+var x: string;
+
+type
+  t1 = partial class
+    constructor := x += '1';
+    constructor(p: byte) := x += '2';
+  end;
+  
+  t0 = class
+    constructor := x += '3';
+  end;
+  t1 = partial class(t0) end;
+  
+begin
+  x := '';
+  new t1;
+  Assert(x = '31');
+  x := '';
+  new t1(1);
+  Assert(x = '32');
+end.

--- a/TestSuite/partial_constructor4.pas
+++ b/TestSuite/partial_constructor4.pas
@@ -1,0 +1,17 @@
+﻿var x := 0;
+
+type
+  t1 = partial class end;
+  
+  t0 = class
+    constructor := x := 1;
+    constructor(p: byte) := x := 2;
+  end;
+  t1 = partial class(t0)
+    
+  end;
+  
+begin
+  new t1(5);
+  Assert(x = 2);
+end.

--- a/TestSuite/partial_constructor5.pas
+++ b/TestSuite/partial_constructor5.pas
@@ -1,0 +1,12 @@
+﻿type
+  t0 = class
+    public constructor := exit;
+    public constructor(x: byte) := exit;
+  end;
+  
+  t1 = partial class(t0) end;
+  t1 = partial class(t0) end;
+  
+begin
+  Assert( 2 = typeof(t1).GetConstructors.Length );
+end.

--- a/TestSuite/partial_constructor6.pas
+++ b/TestSuite/partial_constructor6.pas
@@ -1,0 +1,14 @@
+﻿type
+  t1 = partial class end;
+  
+  t0 = class
+    public constructor := exit;
+    public constructor(x: byte) := exit;
+  end;
+  
+  t1 = partial class(t0) end;
+  t1 = partial class(t0) end;
+  
+begin
+  Assert( 2 = typeof(t1).GetConstructors.Length );
+end.

--- a/TreeConverter/TreeConversion/syntax_tree_visitor.cs
+++ b/TreeConverter/TreeConversion/syntax_tree_visitor.cs
@@ -19353,8 +19353,8 @@ namespace PascalABCCompiler.TreeConverter
 
             {
                 var fn = _ctn.base_type.find_in_type(compiler_string_consts.default_constructor_name, _ctn.base_type.Scope)
-                    ?.Select(si=>si.sym_info).OfType<function_node>()
-                    .FirstOrDefault(_fn=>_fn.parameters.Count==0);
+                    ?.Select(si => si.sym_info).OfType<function_node>()
+                    .FirstOrDefault(_fn => _fn.parameters.Count == 0);
                 var base_constructor_call = make_base_constructor_call(fn, out _, out _);
                 if (base_constructor_call != null)
                     foreach (var cmn in _ctn.methods)
@@ -19365,7 +19365,7 @@ namespace PascalABCCompiler.TreeConverter
                             if (cmn.function_code is statements_list st_lst)
                             {
                                 var param_c =
-                                    st_lst.statements[0] is   common_constructor_call mconstr ? mconstr.parameters.Count :
+                                    st_lst.statements[0] is common_constructor_call mconstr ? mconstr.parameters.Count :
                                     st_lst.statements[0] is compiled_constructor_call pconstr ? pconstr.parameters.Count :
                                 throw new NotSupportedException(); // Первый вызов это в любом случае конструктор, но если я что то не учёл - надо будет добавить ещё условия на предыдущей строчке
 
@@ -19415,8 +19415,11 @@ namespace PascalABCCompiler.TreeConverter
                             context.set_field_access_level(mconstr.field_access_level);
 
                         // Иначе partial классам генерирует кучу копий дефолтных конструкторов
-                        if (_ctn.methods.Any(m=>m.is_constructor && m.name == compiler_string_consts.default_constructor_name && m.parameters.Count == fn.parameters.Count))
-                            continue;
+                        if (_ctn.methods.Any(m =>
+                            m.is_constructor && m.name == compiler_string_consts.default_constructor_name &&
+                            m.parameters.Count == fn.parameters.Count &&
+                            m.parameters.Zip(fn.parameters, (par1, par2) => par1.type == par2.type).All(b => b)
+                        )) continue;
 
                         var gen_constr = context.create_function(compiler_string_consts.default_constructor_name, loc) as common_method_node;
                         gen_constr.polymorphic_state = ps;

--- a/TreeConverter/TreeRealization/Collections.cs
+++ b/TreeConverter/TreeRealization/Collections.cs
@@ -142,6 +142,17 @@ namespace PascalABCCompiler.TreeRealization
     [Serializable]
     public class statement_node_list : extendable_collection<statement_node>
     {
+        public new statement_node this[int num]
+        {
+            get
+            {
+                return _elements[num];
+            }
+            set
+            {
+                _elements[num] = value;
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Добавил кучу тестов, чтоб уже наверняка исправить всё.

По алгоритму - вместо того чтоб подменять предыдущий дефолтный конструктор, я сделал так, чтоб новый в принципе не генерировался (но только если предыдущий уже существует).

При этом вместо подмены всего тела конструктора - подменяется только первый оператор. И только если это неявный вызов конструктора предка.
Правда с одним исключением:
```
type
  t1 = partial class
    constructor;
    begin
      inherited Create;
    end;
  end;
  
  t0 = class
    constructor := Writeln('Конструктор предка');
  end;
  t1 = partial class(t0)
    
  end;
  
begin
  new t1;
end.
```
`inherited Create;` тут вызван явно, но при чтении первого тела `t1` - это вызов конструктора `object`, что плохо. Его тоже заменяет на вызов конструктора `t0`.