### PR TITLE
Exit build shell script on first subcommand failed

### DIFF
--- a/_RebuildReleaseAndRunTests.sh
+++ b/_RebuildReleaseAndRunTests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 MONO_IOMAP=case msbuild /p:Configuration=release pabcnetc.sln
 MONO_IOMAP=case msbuild /p:Configuration=release CodeCompletion/CodeCompletion.csproj
 mono --aot bin/pabcnetc.exe


### PR DESCRIPTION
sh -e will cause the shell to exit immediately if a command exits with a
nonzero exit value.