### PR TITLE
Replace a Russian word in the English section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ sh _RebuildReleaseAndRunTests.sh
 ```bash
 $ cd bin
 $ mono pabcnetc.exe
-или $ mono --debug pabcnetc.exe
+or $ mono --debug pabcnetc.exe
 ```
 
 ## Tests


### PR DESCRIPTION
I just spotted a little mistake in the English section of Readme. It was saying "или" instead of "or".