### PR TITLE
Исправление неявного подключения модуля, через 2 uses-in, начинающихся с '../'

### DIFF
--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -2547,8 +2547,9 @@ namespace PascalABCCompiler
 
             for (; dir!="" && i < path.Length && path[i] == '.' && path[i + 1] == '.'; )
             {
+                if (Path.GetFileName(dir) == "..") break;
                 dir = Path.GetDirectoryName(dir);
-                if (string.IsNullOrEmpty(dir)) return null;
+                if (string.IsNullOrEmpty(dir)) break;
                 i += 2;
                 if (path[i] == Path.DirectorySeparatorChar || path[i] == Path.AltDirectorySeparatorChar) i += 1;
             }

--- a/TestSuite/usesunits/UsesInUnits5/1/2/u1.pas
+++ b/TestSuite/usesunits/UsesInUnits5/1/2/u1.pas
@@ -1,0 +1,7 @@
+﻿unit u1;
+
+uses u2 in '..\u2';
+
+var r: r1;
+
+end.

--- a/TestSuite/usesunits/UsesInUnits5/1/u2.pas
+++ b/TestSuite/usesunits/UsesInUnits5/1/u2.pas
@@ -1,0 +1,8 @@
+﻿unit u2;
+
+uses u3 in '..\u3';
+
+type
+  r1 = u3.r1;
+  
+end.

--- a/TestSuite/usesunits/UsesInUnits5/u3.pas
+++ b/TestSuite/usesunits/UsesInUnits5/u3.pas
@@ -1,0 +1,7 @@
+﻿unit u3;
+
+type
+  // Не важно класс изи запись
+  r1 = record end;
+  
+end.

--- a/TestSuite/usesunits/uses_in5_back+back.pas
+++ b/TestSuite/usesunits/uses_in5_back+back.pas
@@ -1,0 +1,1 @@
+﻿## uses u1 in 'UsesInUnits5\1\2\u1';


### PR DESCRIPTION
Текст нового теста сам большую часть объясняет. Подробнее:
`u1` в тесте неявно подключает `u3`.
При этом в `u1.pcu` надо сохранить по какому пути `u1` подключает `u3`.
Для этого соединялось имя папки модуля `u2` (которое `..`, то есть "перейти в предыдущую папку") и `../u3` - которое подключается к `u2`.
Но при этом `..` считало не особым именем, а обычным именем папки и в результате путь от u1 к u3 получался просто `u3` вместо `../../u3`.