### PR TITLE
Агрумент консольного компилятора /Define

### DIFF
--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -553,6 +553,8 @@ namespace PascalABCCompiler
         //
         public string SystemDirectory;
 
+        public List<string> ForceDefines = new List<string>();
+
         public List<string> SearchDirectory;
 
         private bool useDllForSystemUnits = false;
@@ -2981,6 +2983,7 @@ namespace PascalABCCompiler
                 DefinesList.Add("RELEASE");
             else
                 DefinesList.Add("DEBUG");
+            DefinesList.AddRange(CompilerOptions.ForceDefines);
             SyntaxTree.compilation_unit SyntaxTree = InternalParseText(FileName, SourceText, errorsList, warnings, DefinesList);
             if (errorsList.Count > 0)
                 throw errorsList[0];
@@ -3277,6 +3280,7 @@ namespace PascalABCCompiler
                     DefinesList.Add("RELEASE");
                 else
                     DefinesList.Add("DEBUG");
+                DefinesList.AddRange(CompilerOptions.ForceDefines);
                 if (compilerOptions.UnitSyntaxTree != null)
                 {
                     CurrentUnit.SyntaxTree = compilerOptions.UnitSyntaxTree;

--- a/pabcnetc_clear/ConsoleCompiler.cs
+++ b/pabcnetc_clear/ConsoleCompiler.cs
@@ -76,6 +76,10 @@ namespace PascalABCCompiler
                             return false;
                     }
 
+                case "define":
+                    co.ForceDefines.Add(value);
+                    return true;
+
                 case "output":
                     co.OutputFileName = Path.GetFileName(value);
                     if (Path.IsPathRooted(value))
@@ -111,12 +115,14 @@ namespace PascalABCCompiler
             Console.WriteLine("pabcnetcclear /directive1:value1 /directive2:value2 ... [inputfile]\n");
             Console.WriteLine("Available directives:");
             Console.WriteLine("  /Help  /H  /?");
-            Console.WriteLine("  /Debug:0(1)");
-            Console.WriteLine("  /output:[<path>\\name]");
+            Console.WriteLine("  /Debug:<0/1>");
+            Console.WriteLine("  /Define:<name>");
+            Console.WriteLine("  /Output:<[path\\]name>");
             Console.WriteLine("  /SearchDir:<path>");
             Console.WriteLine();
-            Console.WriteLine("/output:[ <path>\\name ] compile into an executable called \"name\" and save it in \"path\" directory");
-            Console.WriteLine("/Debug:0 generates code with all .NET optimizations!");
+            Console.WriteLine("/Help show this message");
+            Console.WriteLine("/Output:<[path\\]name> compile into an executable called \"name\" and save it in \"path\" directory");
+            Console.WriteLine("/Debug:0 generates code with all .NET optimizations");
             Console.WriteLine("/SearchDir:<path> add \"path\" to list of standart unit search directories. Last added paths would be searched first");
         }
 

--- a/pabcnetc_clear/ConsoleCompiler.cs
+++ b/pabcnetc_clear/ConsoleCompiler.cs
@@ -51,7 +51,7 @@ namespace PascalABCCompiler
             name = ss[0].ToLower();
             if (ss.Length > 1)
             {
-                value = ss[1].Trim().ToLower();
+                value = ss[1].Trim();
             }
 
             return true;


### PR DESCRIPTION
Тот же `{$define}`, но работает из вне .pas файла.
Нужно, чтоб автоматически генерировать особую версию .exe из существующих .pas файлов.
К примеру, версию с дополнительными фичами дебага, для особых проверок во время работы тестировщика проекта.