### PR TITLE
Аргумент консольного компилятора "/Locale"

### DIFF
--- a/pabcnetc_clear/ConsoleCompiler.cs
+++ b/pabcnetc_clear/ConsoleCompiler.cs
@@ -92,6 +92,10 @@ namespace PascalABCCompiler
                     co.SearchDirectory.Insert(0, value); // .Insert, чтобы определённые пользователем папки имели бОльший приоритет, чем стандартная
                     return true;
 
+                case "locale":
+                    co.Locale = value;
+                    return true;
+
                 default:
                     Console.WriteLine("No such directive name: '{0}'", name);
                     return false;
@@ -119,12 +123,14 @@ namespace PascalABCCompiler
             Console.WriteLine("  /Define:<name>");
             Console.WriteLine("  /Output:<[path\\]name>");
             Console.WriteLine("  /SearchDir:<path>");
+            Console.WriteLine("  /Locale:<locale>");
             Console.WriteLine("  /Version:");
             Console.WriteLine();
             Console.WriteLine("/Help show this message");
             Console.WriteLine("/Output:<[path\\]name> compile into an executable called \"name\" and save it in \"path\" directory");
             Console.WriteLine("/Debug:0 generates code with all .NET optimizations");
             Console.WriteLine("/SearchDir:<path> add \"path\" to list of standart unit search directories. Last added paths would be searched first");
+            Console.WriteLine("/Locale:<locale> set locale of main thread of compiled program executable");
             Console.WriteLine("/Version: outputs PascalABC.NET version");
         }
 


### PR DESCRIPTION
Решил разобраться с тем, почему у меня в тестах ошибок POCGL где-то ошибки на русском, где-то на англ., а где то всё в перемешку.

В итоге в очередной раз разобрался, что в инициализации `PABCSystem` выполняется:
```
  System.Threading.Thread.CurrentThread.CurrentUICulture := System.Globalization.CultureInfo.GetCultureInfo(locale_str);
```
`locale_str` всегда будет русской, если компилятор явно не указал иначе. А (без этого пула) другие значения возможны только при компиляции из IDE.

- Эту штуку так просто из инициализации программы не вычленишь.
- Перезапись `CurrentUICulture` между тем что делает `PABCSystem` и запуском кода программы вставить рефлекцией не выйдет. Возможно можно инъекциями кода, но это слишком.
- В начале каждой программы теста вставлять эту строчку тоже глупо - это десятки дублей одного кода.

По моему лучше если бы сделать так:
1. `PABCSystem` меняет `CurrentUICulture` только если значение переменной `__CONFIG__` явно установлено. Никакого дефолта на русский.
2. IDE явно установливает свойство опций компилятора `.Locale` (оно влияет на `__CONFIG__`) на язык интерфейса. Ну, это и так происходит.
3. `pabcnetc` устанавливает `.Locale` на русский, если явно не указать в его консольном интерфейсе. Таким образом ПКМ на .pas файл в папке и "Компилировать" продолжает работать как раньше. P.S. Хотя тоже не понятно зачем тут дефолтить на русский...

---

# Но пока что, то что я сделал:

Добавил в `pabcnetcclear` новый аргумент, указывающий какая культура установится первому потоку при запуске программы.
Звучит как ужасный костыль... Но по крайней мере заполняет дырку в возможностях - теперь можно менять это значение без открытия IDE для каждого файла теста.