### PR TITLE
Месседжбокс "Файл был изменён" в отдельный поток

### DIFF
--- a/VisualPascalABCNET/FileMonitoring.cs
+++ b/VisualPascalABCNET/FileMonitoring.cs
@@ -90,17 +90,18 @@ namespace VisualPascalABC
 
         void MainForm_Activated(object sender, EventArgs e) => System.Threading.Tasks.Task.Run(() =>
         {
+            if (!wasChangedExternally) return;
+            wasChangedExternally = false;
             try
             {
-                if (wasChangedExternally)
+                string mes = null;
+                if (!File.Exists(fileName))
                 {
-                    wasChangedExternally = false;
-
-                    string mes = null;
-                    if (!File.Exists(fileName))
+                    mes = Form1StringResources.Get("FILE_NOT_EXIST_MESSAGE");
+                    var dr = MessageBox.Show(fileName + "\n\n" + mes, Form1StringResources.Get("CHANGED_FILE"), MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                    VisualPABCSingleton.MainForm.Invoke((Action)(() =>
                     {
-                        mes = Form1StringResources.Get("FILE_NOT_EXIST_MESSAGE");
-                        if (MessageBox.Show(fileName + "\n\n" + mes, Form1StringResources.Get("CHANGED_FILE"), MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+                        if (dr == DialogResult.Yes)
                         {
                             WorkbenchServiceFactory.FileService.SetFileAsChanged(fileName);
                         }
@@ -108,24 +109,27 @@ namespace VisualPascalABC
                         {
                             WorkbenchServiceFactory.FileService.CloseFile(fileName);
                         }
-                        return;
-                    }
-
-                    mes = Form1StringResources.Get("FILE_CHANGED_MESSAGE");
-                    if (MessageBox.Show(fileName + "\n\n" + mes, Form1StringResources.Get("CHANGED_FILE"), MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
-                    {
-                        WorkbenchServiceFactory.FileService.ReloadFile(fileName);
-                    }
-                    else
-                    {
-                        WorkbenchServiceFactory.FileService.SetFileAsChanged(fileName);
-                    }
+                    }));
                 }
-            }
-            catch (Exception)
-            {
+                else
+                {
+                    mes = Form1StringResources.Get("FILE_CHANGED_MESSAGE");
+                    var dr = MessageBox.Show(fileName + "\n\n" + mes, Form1StringResources.Get("CHANGED_FILE"), MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                    VisualPABCSingleton.MainForm.Invoke((Action)(() =>
+                    {
+                        if (dr == DialogResult.Yes)
+                        {
+                            WorkbenchServiceFactory.FileService.ReloadFile(fileName);
+                        }
+                        else
+                        {
+                            WorkbenchServiceFactory.FileService.SetFileAsChanged(fileName);
+                        }
+                    }));
+                }
 
             }
+            catch (Exception) {}
         });
 
     }

--- a/VisualPascalABCNET/FileMonitoring.cs
+++ b/VisualPascalABCNET/FileMonitoring.cs
@@ -88,7 +88,7 @@ namespace VisualPascalABC
             }
         }
 
-        void MainForm_Activated(object sender, EventArgs e)
+        void MainForm_Activated(object sender, EventArgs e) => System.Threading.Tasks.Task.Run(() =>
         {
             try
             {
@@ -122,11 +122,11 @@ namespace VisualPascalABC
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
 
             }
-        }
+        });
 
     }
 }


### PR DESCRIPTION
```
{$reference System.Windows.Forms.dll}
{$reference System.Drawing.dll}
{$apptype windows}

uses System.Windows.Forms;
uses System.Drawing;

begin
  var MainForm := new Form;
  
  MainForm.Activated += (o,e)->
  begin
    MessageBox.Show(nil);
  end;
  
  Application.Run(MainForm);
end.
```
Попробуйте закрыть окно нажав на крестик.
Это невозможно, потому что окно программы прячется за окна других программ при закрытии месседжбокса.
https://youtu.be/hmICbhDRyhQ

---

Так вот - примерно то же самое сейчас делает IDE паскаля.
Я тупо засунул код, создающий месседжбоксы, в `Task.Run`.
И только в одном месте - там где это достало меня, потому что я часто работаю с кодогенераторами в POCGL, то есть с ситуациями где одна программа меняет текст другой.

Этот пулл это **только пример исправлений**, лучше если вы разберётесь сами как лучше переделать и + посмотрите на остальные места где создаются месседжбоксы.