### PR TITLE
(#2718) NetHelper: fix type lookup when it has several entries

### DIFF
--- a/TreeConverter/NetWrappers/NetHelper.cs
+++ b/TreeConverter/NetWrappers/NetHelper.cs
@@ -2081,7 +2081,7 @@ namespace PascalABCCompiler.NetHelper
 		
 		public static Type FindTypeOrCreate(string name)
 		{
-			TypeInfo ti = (TypeInfo)types[name];
+			TypeInfo ti = types[name] as TypeInfo;
 			if (ti != null /*&& cur_used_assemblies.ContainsKey(t.Assembly)*/) return ti.type;
 			//ivan added - runtime types adding
 			Type t = Type.GetType(name, false, true);


### PR DESCRIPTION
Closes #2718.

I'm not sure my fix is correct, but it unblocks a huge chunk of work on PascalABC.NET SDK (since various wild reference assemblies containing type `T` no longer can cause a compilation error, provided that the types in question are unused by my Pascal programs).