### PR TITLE
Чистка за #2727 и исправление заранее созданных подстановок в шаблон типа

### DIFF
--- a/NETGenerator/NETGenerator.cs
+++ b/NETGenerator/NETGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Ivan Bondarev, Stanislav Mikhalkovich (for details please see \doc\copyright.txt)
+// Copyright (c) Ivan Bondarev, Stanislav Mikhalkovich (for details please see \doc\copyright.txt)
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
 using System;
 using System.Linq;
@@ -1523,7 +1523,10 @@ namespace PascalABCCompiler.NETGenerator
             {
                 AddTypeWithoutConvert(t);
             }
-            foreach (ITypeNode interf in t.ImplementingInterfaces)
+            // ImplementingInterfacesOrEmpty, потому что если интерфейсы небыли лениво-посчитаны семантикой
+            // То и тут их обходить нет смысла
+            // А в ошибочных ситуациях (как err0303.pas) может ещё и зациклится
+            foreach (ITypeNode interf in t.ImplementingInterfacesOrEmpty)
                 if (!(interf is ICompiledTypeNode))
                     ConvertTypeHeaderInSpecialOrder((ICommonTypeNode)interf);
             if (t.base_type != null && !(t.base_type is ICompiledTypeNode))

--- a/SemanticTree/SemanticTree.cs
+++ b/SemanticTree/SemanticTree.cs
@@ -214,6 +214,10 @@ namespace PascalABCCompiler.SemanticTree
         {
             get;
         }
+		List<ITypeNode> ImplementingInterfacesOrEmpty
+        {
+            get;
+        }
 
         //Является ли generic-параметром
         bool is_generic_parameter

--- a/TestSuite/generics66.pas
+++ b/TestSuite/generics66.pas
@@ -1,0 +1,10 @@
+﻿type
+  i1<T> = interface end;
+  i2<T> = interface
+    where T: i1<byte>;
+  end;
+  
+  t1<T> = class(i1<T>, i2<t1<byte>>) end;
+  t2<T> = class(i2<t1<byte>>, i1<T>) end;
+  
+begin end.

--- a/TestSuite/recursive_where_gen.pas
+++ b/TestSuite/recursive_where_gen.pas
@@ -1,0 +1,30 @@
+﻿type
+  i0 = interface end;
+  
+  base_i<TSelf> = interface
+  where TSelf: base_i<TSelf>;
+    function fi(a: TSelf): TSelf;
+  end;
+  
+  base_c<TSelf> = abstract class
+  where TSelf: base_c<TSelf>;
+    function fc(a: TSelf): TSelf; abstract;
+  end;
+  
+  class1<T> = class(i0, base_i<class1<T>>)
+    public function fi(a: class1<T>) := a;
+  end;
+  class2<T> = class(base_c<class2<T>>, base_i<class2<T>>)
+    public function fi(a: class2<T>) := self;
+    public function fc(a: class2<T>): class2<T>; override := self;
+  end;
+  
+  record1<T> = record(i0, base_i<record1<T>>)
+    public function fi(a: record1<T>) := self;
+  end;
+  
+  interface1<T> = interface(i0, base_i<interface1<T>>)
+    
+  end;
+  
+begin end.

--- a/TreeConverter/TreeConversion/syntax_tree_visitor.cs
+++ b/TreeConverter/TreeConversion/syntax_tree_visitor.cs
@@ -3866,12 +3866,16 @@ namespace PascalABCCompiler.TreeConverter
 
             foreach (generic_type_instance_info gti in generic_convertions.get_type_instances(converted_type))
             {
-                //TODO Зачем?
-                if (gti.pseudo_instance.base_type != null && gti.pseudo_instance.base_type.is_generic_type_instance && converted_type.IsPartial) continue;
-                //TODO "t1<T> = class(i1<T>)" => "t1<byte>" реализует "i1<T>" вместо "i1<byte>"???
-                gti.pseudo_instance.SetBaseType(converted_type.base_type);
+                //TODO Было для #2524, но с generic_convertions.determine_type оно не нужно
+                //if (gti.pseudo_instance.base_type != null && gti.pseudo_instance.base_type.is_generic_type_instance && converted_type.IsPartial) continue;
+
+                // "t1<T> = class(i1<T>)" => "t1<byte>" реализует "i1<byte>" а не "i1<T>"
+                gti.pseudo_instance.SetBaseType(generic_convertions.determine_type(converted_type.base_type, gti.param_types, false));
+
                 gti.pseudo_instance.ImplementingInterfaces.Clear();
-                gti.pseudo_instance.ImplementingInterfaces.AddRange(converted_type.ImplementingInterfaces);
+                foreach (type_node t in converted_type.ImplementingInterfaces)
+                    gti.pseudo_instance.ImplementingInterfaces.Add(generic_convertions.determine_type(t, gti.param_types, false));
+
             }
 
             // Проверяем секции where предка/интерфейсов

--- a/TreeConverter/TreeConversion/syntax_tree_visitor.cs
+++ b/TreeConverter/TreeConversion/syntax_tree_visitor.cs
@@ -3789,12 +3789,12 @@ namespace PascalABCCompiler.TreeConverter
 
             // Для записей базовый класс устанавливает на SemanticRules.StructBaseType ещё в context.create_record_type
             var need_set_base = _class_definition.keyword != PascalABCCompiler.SyntaxTree.class_keyword.Record;
+            // Ограничение шаблонов предка и интерфейсов нельзя проверять
+            // на первом проходе, когда ещё не все предки добавлены в converted_type
+            var need_recheck_where = new List<syntax_tree_node>();
             if (_class_definition.class_parents != null)
             {
-                // Ограничение шаблонов предка и интерфейсов нельзя проверять
-                // на первом проходе, когда они не добавлены в converted_type
-                var need_recheck_where = new List<syntax_tree_node>(_class_definition.class_parents.Count);
-
+                need_recheck_where.Capacity = _class_definition.class_parents.Count;
                 // В случае partial классов можно (и желательно) указывать интерфейсы, которые уже были в предыдущем описании
                 // Поэтому проверять нужно только уникальное среди списка интерфейсов в этом описании
                 var curr_def_interfaces = new List<type_node>(need_recheck_where.Capacity);
@@ -3854,13 +3854,6 @@ namespace PascalABCCompiler.TreeConverter
 
                 }
                 context.skip_check_where_sections = false;
-
-                // Проверяем секции where предка/интерфейсов
-                // В самом конце, когда converted_type
-                // уже содержит всю информацию о предке и интерфейсах
-                foreach (var syntax_tn in need_recheck_where)
-                    ret.visit(syntax_tn);
-
             }
 
             if (need_set_base)
@@ -3871,12 +3864,21 @@ namespace PascalABCCompiler.TreeConverter
                 converted_type.SetBaseType(bt);
             }
 
-            if (_class_definition.keyword==PascalABCCompiler.SyntaxTree.class_keyword.Class)
-                foreach (generic_type_instance_info gti in generic_convertions.get_type_instances(converted_type))
-                {
-                    if (!(gti.pseudo_instance.base_type != null && gti.pseudo_instance.base_type.is_generic_type_instance && converted_type.IsPartial))
-                        gti.pseudo_instance.SetBaseType(converted_type.base_type);
-                }
+            foreach (generic_type_instance_info gti in generic_convertions.get_type_instances(converted_type))
+            {
+                //TODO Зачем?
+                if (gti.pseudo_instance.base_type != null && gti.pseudo_instance.base_type.is_generic_type_instance && converted_type.IsPartial) continue;
+                //TODO "t1<T> = class(i1<T>)" => "t1<byte>" реализует "i1<T>" вместо "i1<byte>"???
+                gti.pseudo_instance.SetBaseType(converted_type.base_type);
+                gti.pseudo_instance.ImplementingInterfaces.Clear();
+                gti.pseudo_instance.ImplementingInterfaces.AddRange(converted_type.ImplementingInterfaces);
+            }
+
+            // Проверяем секции where предка/интерфейсов
+            // В самом конце, когда converted_type
+            // уже содержит всю информацию о предке и интерфейсах
+            foreach (var syntax_tn in need_recheck_where)
+                ret.visit(syntax_tn);
 
             switch (_class_definition.keyword)
             {

--- a/TreeConverter/TreeConversion/syntax_tree_visitor.cs
+++ b/TreeConverter/TreeConversion/syntax_tree_visitor.cs
@@ -3872,9 +3872,13 @@ namespace PascalABCCompiler.TreeConverter
                 // "t1<T> = class(i1<T>)" => "t1<byte>" реализует "i1<byte>" а не "i1<T>"
                 gti.pseudo_instance.SetBaseType(generic_convertions.determine_type(converted_type.base_type, gti.param_types, false));
 
+                // Сбрасываем на null, чтобы их вычислило заново, если понадобится
+                gti.pseudo_instance.SetImplementingInterfaces(null);
+                /**
                 gti.pseudo_instance.ImplementingInterfaces.Clear();
                 foreach (type_node t in converted_type.ImplementingInterfaces)
                     gti.pseudo_instance.ImplementingInterfaces.Add(generic_convertions.determine_type(t, gti.param_types, false));
+                /**/
 
             }
 

--- a/TreeConverter/TreeRealization/types.cs
+++ b/TreeConverter/TreeRealization/types.cs
@@ -219,6 +219,13 @@ namespace PascalABCCompiler.TreeRealization
                 return null;
             }
         }
+        public virtual List<SemanticTree.ITypeNode> ImplementingInterfacesOrEmpty
+        {
+            get
+            {
+                return ImplementingInterfaces;
+            }
+        }
 
         //true, если на данный момент имеется только предописание класса
         public virtual bool ForwardDeclarationOnly
@@ -2601,7 +2608,7 @@ namespace PascalABCCompiler.TreeRealization
                 generic_convertions.MakePseudoInstanceName(name, param_types, true),
                 SemanticTree.type_access_level.tal_public, null, this.loc);
             _generic_instances.Add(new generic_type_instance_info(param_types, ctnode));
-            generic_convertions.init_generic_instance(this, ctnode, param_types);
+            generic_convertions.init_generic_instance(ctnode);
             return ctnode;
         }
 
@@ -3175,7 +3182,7 @@ namespace PascalABCCompiler.TreeRealization
                 generic_convertions.MakePseudoInstanceName(name, param_types, true),
                 SemanticTree.type_access_level.tal_public, null, /*ct_scope,*/ this.loc);
             _generic_instances.Add(new generic_type_instance_info(param_types, ctnode));
-            generic_convertions.init_generic_instance(this, ctnode, /*ct_scope,*/ param_types);
+            generic_convertions.init_generic_instance(ctnode/*, ct_scope*/);
             return ctnode;
         }
         //\ssyy


### PR DESCRIPTION
https://github.com/SunSerega/pascalabcnet/actions/runs/3198665661

- Тест `recursive_where_gen.pas` это дубль теста `recursive_where.pas` из #2727, но все дочереные типы сделаны шаблонными.
После того пула так всё ещё не работало, потому что для них `foreach (generic_type_instance_info gti ...` надо делать перед проверками `where`.

- Тест `generics66.pas` частично работал до первого коммита этого пула: `t1<T>` компилировался, а `t2<T>` нет.
После первого коммита и `t1<T>` перестал компилироваться, а второй коммит исправил оба случая.

