### PR TITLE
Правильное имя файла в ошибках `uses`

### DIFF
--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Ivan Bondarev, Stanislav Mikhalkovich (for details please see \doc\copyright.txt)
+// Copyright (c) Ivan Bondarev, Stanislav Mikhalkovich (for details please see \doc\copyright.txt)
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
  /***************************************************************************
  *   
@@ -2725,7 +2725,7 @@ namespace PascalABCCompiler
                 TryThrowInvalidPath(uui.in_file.Value, uui.in_file.source_context);
 
                 if (UnitName.ToLower() != Path.GetFileNameWithoutExtension(uui.in_file.Value).ToLower())
-                    throw new UsesInWrongName(CurrentCompilationUnit.SyntaxTree.file_name, UnitName, Path.GetFileNameWithoutExtension(uui.in_file.Value), uui.in_file.source_context);
+                    throw new UsesInWrongName(SyntaxUsesUnit.source_context.FileName, UnitName, Path.GetFileNameWithoutExtension(uui.in_file.Value), uui.in_file.source_context);
 
             }
 
@@ -2755,7 +2755,7 @@ namespace PascalABCCompiler
                     // если где то ещё будет исопльзоваться UnitName или source_context - надо будет добавить такую же проверку
                     throw new InvalidOperationException(nameof(UnitName));
                 else
-                    throw new UnitNotFound(CurrentCompilationUnit.SyntaxTree.file_name, UnitName, source_context);
+                    throw new UnitNotFound(source_context.FileName, UnitName, source_context);
 
             if (PCUFileExists && SourceFileExists)
             {

--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Ivan Bondarev, Stanislav Mikhalkovich (for details please see \doc\copyright.txt)
+﻿// Copyright (c) Ivan Bondarev, Stanislav Mikhalkovich (for details please see \doc\copyright.txt)
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
  /***************************************************************************
  *   


### PR DESCRIPTION
Припоминаю, когда делал изначальный рекурсивный `uses-in` - взял `CurrentCompilationUnit.SyntaxTree.file_name` из предыдущей реализации не задумываясь.

Теперь заменил на файл контекста синтаксической ноды `uses` - поэтому такое же проблемы быть не может:
![image](https://user-images.githubusercontent.com/27270190/232332837-f775598a-2c21-479a-979f-b94cbbb86909.png)

Так же добавил в #2656, потому что он меняет тот же кусок кода.
В общем случае так делать конечно не хорошо, но тут изменение тривиальное, бороться с конфликтами иначе будет больше лишнего труда.
Проще говоря, если примете тот пулл - этот не нужен.

https://github.com/SunSerega/pascalabcnet/actions/runs/4714641880
