### PR TITLE
Чистка за #2819

### DIFF
--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -2029,9 +2029,8 @@ namespace PascalABCCompiler
                     TryThrowInvalidPath(cds[0].directive, cds[0].location);
                     // Тут не обязательно нормализовывать путь
                     // И если он слишком длинный - File.Exists вернёт false
-                    if (File.Exists(cdo.MainResourceFileName))
-                        cdo.MainResourceFileName = Path.Combine(Path.GetDirectoryName(cds[0].source_file), cds[0].directive);
-                    else
+                    cdo.MainResourceFileName = Path.Combine(Path.GetDirectoryName(cds[0].source_file), cds[0].directive);
+                    if (!File.Exists(cdo.MainResourceFileName))
                         ErrorsList.Add(new ResourceFileNotFound(cds[0].directive, cds[0].location));
                 }
 


### PR DESCRIPTION
Только сейчас заметил, `File.Exists` применяется перед присвоением `cdo.MainResourceFileName` - в итоге для всех `$mainresource` пишет будто файл ресурса не найден.