### PR TITLE
Добавление `LambdaAnySynToSemConverter.dll` to zip релиз

### DIFF
--- a/ReleaseGenerators/PascalABCNETConsoleZIP.bat
+++ b/ReleaseGenerators/PascalABCNETConsoleZIP.bat
@@ -1,6 +1,6 @@
 cd ..\bin
 del ..\Release\PACNETConsole.zip
-..\utils\pkzipc\pkzipc.exe -add ..\Release\PABCNETC.zip pabcnetc.exe pabcnetcclear.exe Compiler.dll CompilerTools.dll Errors.dll Localization.dll NETGenerator.dll ParserTools.dll ICSharpCode.NRefactory.dll SemanticTree.dll SyntaxTree.dll TreeConverter.dll OptimizerConversion.dll PascalABCParser.dll licence.txt PascalABCNET.chm System.Threading.dll SyntaxTreeConverters.dll YieldHelpers.dll SyntaxVisitors.dll
+..\utils\pkzipc\pkzipc.exe -add ..\Release\PABCNETC.zip pabcnetc.exe pabcnetcclear.exe Compiler.dll CompilerTools.dll Errors.dll Localization.dll NETGenerator.dll ParserTools.dll ICSharpCode.NRefactory.dll SemanticTree.dll SyntaxTree.dll TreeConverter.dll OptimizerConversion.dll PascalABCParser.dll licence.txt PascalABCNET.chm System.Threading.dll SyntaxTreeConverters.dll YieldHelpers.dll SyntaxVisitors.dll LambdaAnySynToSemConverter.dll
 ..\utils\pkzipc\pkzipc.exe -add -nozip -dir ..\Release\PABCNETC.zip Lib\*.pcu
 ..\utils\pkzipc\pkzipc.exe -add -nozip -dir ..\Release\PABCNETC.zip Lng\*.dat
 ..\utils\pkzipc\pkzipc.exe -add -nozip -dir ..\Release\PABCNETC.zip Lng\*.LanguageName


### PR DESCRIPTION
Сейчас при попытке что-либо компилировать с помощью `pabcnetcclear.exe` - я получаю следующую ошибку:
```
Unhandled Exception: System.IO.FileNotFoundException: Could not load file or assembly 'LambdaAnySynToSemConverter, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. The system cannot find the file specified.
   at PascalABCCompiler.SyntaxTreeConverters.SyntaxTreeConvertersController.AddStandardConverters()
   at PascalABCCompiler.SyntaxTreeConverters.SyntaxTreeConvertersController.AddConverters()
   at PascalABCCompiler.Compiler.Reload()
   at PascalABCCompiler.ConsoleCompiler.Main(String[] args)
```
Похоже, вы забыли добавить этот файл в zip релиз...

P.S. Пересобрал - теперь компиляция работает.