### PR TITLE
Исправление... Чего то?

### DIFF
--- a/Optimizer/Optimizer.cs
+++ b/Optimizer/Optimizer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Ivan Bondarev, Stanislav Mikhalkovich (for details please see \doc\copyright.txt)
+﻿// Copyright (c) Ivan Bondarev, Stanislav Mikhalkovich (for details please see \doc\copyright.txt)
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
 using System;
 using System.Collections.Generic;
@@ -595,7 +595,7 @@ namespace PascalABCCompiler
                 {
                     tuple_decomp = true;
                     if (vdn.type is generic_instance_type_node)
-                        tuples_num = (vdn.type as generic_instance_type_node).generic_params.Count;
+                        tuples_num = (vdn.type as generic_instance_type_node).instance_params.Count;
                     else if (vdn.type is compiled_type_node)
                         tuples_num = (vdn.type as compiled_type_node).compiled_type.GetGenericArguments().Length;
                     continue;


### PR DESCRIPTION
Контекст: https://github.com/pascalabcnet/pascalabcnetide/issues/250
При исправлении той issue @ibond84 добавил код:
```
                    if (vdn.type is generic_instance_type_node)
                        tuples_num = (vdn.type as generic_instance_type_node).generic_params.Count;
                    else if (vdn.type is compiled_type_node)
                        tuples_num = (vdn.type as compiled_type_node).compiled_type.GetGenericArguments().Length;
```
Но в каком то случае у меня кидало `NullReferenceException`.
В студии дебагом я понял что проблема в том, что `.generic_params` было `null`.
`.generic_params`, вообще, выглядело неправильно: Тут проверяется сколько типов которые подставили в `vdn.type.original_generic`, а не сколько типов можно подставить в `vdn.type`.
Ну, я отложил этот вопрос, чтобы сначала найти источник более неприятного краша (#2892) - и теперь не могу воспроизвести или даже понять, когда до этого кода вообще доходит выполнение в именно компиляторе (а не анализаторе кода).
Но исправление вроде всё равно по делу. @ibond84 можете подтвердить?

https://github.com/SunSerega/pascalabcnet/actions/runs/5381911371