### PR TITLE
Исправление #2901

### DIFF
--- a/Compiler/PCU/PCUReader.cs
+++ b/Compiler/PCU/PCUReader.cs
@@ -783,7 +783,7 @@ namespace PascalABCCompiler.PCU
                 t = NetHelper.NetHelper.FindTypeOrCreate(type_name);
             if (t == null || type_name.IndexOf('.') == -1)
             {
-                ts.name = type_name;
+                ts.name = type_name.Remove(0, type_name.LastIndexOf('.') + 1);
                 return ts;
             }
             Type[] template_types = new Type[pcu_file.dotnet_names[off].addit.Length];


### PR DESCRIPTION
В `PCUReader.FindSpecTypeByHandle()` имена типов переводятся в `PCUReader.TypeSpec`

Обычно заполняется поле `TypeSpec.t`, но если `System.Type` получить не удалось, то заполняется `TypeSpec.name`

`SystemType` для `System.Windows.UIElement` получить как раз не удалось (`NetHelper.FindTypeOrCreate(type_name)` возвращает `null`). Поэтому заполнилось поле `name` как "**System.Windows**.UIElement"

Дальше экземпляр `TypeSpec` уходит в `PCUReader.ChooseConstructor()` где поле `name` сравнивается с `System.Type.Name`, которое всегда возвращает имя типа без неймспейса. `TypeSpec.name` был заполнен с неймспейсом

В `.FindSpecTypeByHandle()` уже применялась практика обрезки неймспейса чуть ниже по коду, так что я просто добавил её и сюда

<details>
<summary>Спойлер: Лирическое отступление</summary>
Но, наверно, стоит в будущем разобраться, почему `.FindTypeOrCreate()` не может найти тип 

UPD: оно не может найти тип, если он находится в сборке, напрямую не подключенной к программе
UPD2: хотя это не единственная причина. Но явное подключение недостающей библиотеки помогало в случае с `UIElement`
</details> 
