### PR TITLE
(#2905) Short-term solution: load Microsoft assemblies via Assembly::LoadFrom

### DIFF
--- a/TreeConverter/NetWrappers/NetHelper.cs
+++ b/TreeConverter/NetWrappers/NetHelper.cs
@@ -363,6 +363,12 @@ namespace PascalABCCompiler.NetHelper
 
         public static Assembly PreloadAssembly(string name)
         {
+            if (Path.GetFileName(name).ToLowerInvariant().Contains("microsoft."))
+            {
+                // TODO: A workaround for https://github.com/pascalabcnet/pascalabcnet/issues/2905
+                return Assembly.LoadFrom(name); 
+            }
+            
             var bytes = File.ReadAllBytes(name);
             return Assembly.Load(bytes);
         }


### PR DESCRIPTION
In #2905, we still have a resource leak even after this patch.

As a mid-term solution, I am planning to add a static cache for resolved assemblies.

As a long-term solution, I'll try to find a proper _scope_ for the assemblies used during a particular compilation, and maybe even try to unload them after a compilation request has been processed.

This way, our compiler process will become reusable for different projects and won't have the leaked assemblies in it indefinitely.