### PR TITLE
(#2905) More design fixes for AssemblyResolveScope, fix leaks

### DIFF
--- a/TreeConverter/NetWrappers/NetHelper.cs
+++ b/TreeConverter/NetWrappers/NetHelper.cs
@@ -364,18 +364,6 @@ namespace PascalABCCompiler.NetHelper
 			return false;
 		}
 
-        public static Assembly PreloadAssembly(string name)
-        {
-            if (Path.GetFileName(name).ToLowerInvariant().Contains("microsoft."))
-            {
-                // TODO: A workaround for https://github.com/pascalabcnet/pascalabcnet/issues/2905
-                return Assembly.LoadFrom(name); 
-            }
-            
-            var bytes = File.ReadAllBytes(name);
-            return Assembly.Load(bytes);
-        }
-
 		public static Assembly LoadAssembly(string name, bool use_load_from = false)
 		{
             if (name == null) return null;
@@ -426,7 +414,8 @@ namespace PascalABCCompiler.NetHelper
 			//if (!System.IO.Path.GetFileName(name).ToLower().Contains("microsoft.directx"))
             try
             {
-                a = PreloadAssembly(name);
+                var bytes = File.ReadAllBytes(name);
+                a = Assembly.Load(bytes);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Этот pull request исправляет утечку ресурсов, которую мы обнаружили в #2905 (и которая была ранее добавлена моим же предыдущим pull request'ом).

Поскольку у нас теперь единый `AssemblyResolveScope` на все процессы перекомпиляции (я не придумал, как можно сделать что-то лучше решения от @ibond84), то я решил настроить кэширование в этом контексте.

Воркэраунд для сборок от Microsoft стал не нужен — теперь все сборки одинаково правильно грузятся общим кодом (во всяком случае, пример с Microsoft.ML теперь компилируется хорошо).

Отдельный метод `NetHelper.PreloadAssembly` тоже перестал быть нужен.