### PR TITLE
Generate application configuration files on compilation

### DIFF
--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -2271,6 +2271,9 @@ namespace PascalABCCompiler
                             if (compilerOptions.UseDllForSystemUnits)
                                 cdo.RtlPABCSystemType = NetHelper.NetHelper.FindRtlType("PABCSystem.PABCSystem");
                             CodeGeneratorsController.Compile(pn, CompilerOptions.OutputFileName, CompilerOptions.SourceFileName, cdo, CompilerOptions.StandartDirectories, ResourceFilesArray);
+                            CodeGeneratorsController.EmitAssemblyRedirects(
+                                assemblyResolveScope,
+                                CompilerOptions.OutputFileName);
                             if (res_file != null)
                                 File.Delete(res_file);
                         }

--- a/NETGenerator/AppConfigUtil.cs
+++ b/NETGenerator/AppConfigUtil.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+
+namespace NETGenerator
+{
+    internal static class AppConfigUtil
+    {
+        private static class Namespaces
+        {
+            public const string Asm = "urn:schemas-microsoft-com:asm.v1";
+        }
+
+        private static class Elements
+        {
+            public static readonly XName Configuration = "configuration";
+            public static readonly XName Runtime = "runtime";
+
+            public static readonly XName AssemblyBinding = XName.Get("assemblyBinding", Namespaces.Asm);
+            public static readonly XName DependentAssembly = XName.Get("dependentAssembly", Namespaces.Asm);
+            public static readonly XName AssemblyIdentity = XName.Get("assemblyIdentity", Namespaces.Asm);
+            public static readonly XName BindingRedirect = XName.Get("bindingRedirect", Namespaces.Asm);
+        }
+
+        public static void UpdateAppConfig(
+            ICollection<AssemblyName> bindingRedirects,
+            string appConfigPath)
+        {
+            if (bindingRedirects.Count == 0) return;
+            var config = File.Exists(appConfigPath)
+                ? XDocument.Load(appConfigPath)
+                : new XDocument(new XElement(Elements.Configuration));
+            var assemblyBinding = config.GetOrCreateElement(
+                Elements.Configuration,
+                Elements.Runtime,
+                Elements.AssemblyBinding);
+
+            var hasChanges = false;
+            foreach (var redirect in bindingRedirects)
+            {
+                hasChanges |= assemblyBinding.CreateOrUpdateDependentAssembly(redirect);
+            }
+
+            if (hasChanges)
+            {
+                config.Save(appConfigPath);
+            }
+        }
+
+        private static XElement GetOrCreateElement(this XContainer container, params XName[] names)
+        {
+            if (names.Length == 0) throw new ArgumentException("names should not be empty.", nameof(names));
+
+            var currentPosition = container;
+            foreach (var name in names)
+            {
+                var existingElement = currentPosition.Element(name);
+                if (existingElement != null)
+                {
+                    currentPosition = existingElement;
+                }
+                else
+                {
+                    var newElement = new XElement(name);
+                    currentPosition.Add(newElement);
+                    currentPosition = newElement;
+                }
+            }
+
+            return (XElement)currentPosition;
+        }
+
+        private static bool CreateOrUpdateDependentAssembly(this XContainer assemblyBinding, AssemblyName assemblyName)
+        {
+            var assemblyPublicKeyToken = assemblyName.GetPublicKeyToken();
+            if (assemblyPublicKeyToken == null) return false;
+            var publicKeyTokenString = string.Join(
+                "",
+                assemblyName.GetPublicKeyToken().Select(b => b.ToString("x2", CultureInfo.InvariantCulture)));
+            var assemblyCulture = string.IsNullOrEmpty(assemblyName.CultureInfo?.Name)
+                ? "neutral"
+                : assemblyName.CultureInfo?.Name;
+
+            foreach (var dependentAssembly in assemblyBinding.Elements(Elements.DependentAssembly))
+            {
+                var identity = dependentAssembly.Element(Elements.AssemblyIdentity);
+                if (identity == null) continue;
+                var name = identity.Attribute("name")?.Value;
+                var publicKeyToken = identity.Attribute("publicKeyToken")?.Value;
+                var culture = identity.Attribute("culture")?.Value;
+                if (string.IsNullOrEmpty(culture)) culture = "neutral";
+
+                if (name == assemblyName.Name
+                    && PublicKeyTokenCorresponds(publicKeyToken)
+                    && assemblyCulture == culture)
+                {
+                    var bindingRedirect = dependentAssembly.GetOrCreateElement(Elements.BindingRedirect);
+                    {
+                        return UpdateBindingRedirect(bindingRedirect);
+                    }
+                }
+            }
+
+            var newAssembly = new XElement(
+                Elements.DependentAssembly,
+                CreateIdentityElement(),
+                CreateBindingRedirect());
+            assemblyBinding.Add(newAssembly);
+            return true;
+
+            bool PublicKeyTokenCorresponds(string publicKeyToken)
+            {
+                return publicKeyToken.Equals(publicKeyTokenString, StringComparison.CurrentCultureIgnoreCase);
+            }
+
+            bool UpdateBindingRedirect(XElement bindingRedirect)
+            {
+                var newVersion = assemblyName.Version.ToString(4);
+                var oldVersionRange = $"0.0.0.0-{newVersion}";
+                var hasChanges =
+                    bindingRedirect.Attribute("oldVersion")?.Value != oldVersionRange
+                    || bindingRedirect.Attribute("newVersion")?.Value != newVersion;
+                if (!hasChanges) return false;
+
+                bindingRedirect.SetAttributeValue("oldVersion", oldVersionRange);
+                bindingRedirect.SetAttributeValue("newVersion", newVersion);
+                return true;
+            }
+
+            XElement CreateIdentityElement()
+            {
+                var element = new XElement(Elements.AssemblyIdentity);
+                element.SetAttributeValue("name", assemblyName.Name);
+                element.SetAttributeValue("publicKeyToken", publicKeyTokenString);
+                element.SetAttributeValue("culture", assemblyCulture);
+                return element;
+            }
+
+            XElement CreateBindingRedirect()
+            {
+                var element = new XElement(Elements.BindingRedirect);
+                UpdateBindingRedirect(element);
+                return element;
+            }
+        }
+    }
+}

--- a/NETGenerator/CodeGenerator.cs
+++ b/NETGenerator/CodeGenerator.cs
@@ -9,6 +9,7 @@
 
 using System;
 using System.Collections;
+using PascalABCCompiler.NetHelper;
 
 namespace PascalABCCompiler.CodeGenerators
 {
@@ -27,6 +28,9 @@ namespace PascalABCCompiler.CodeGenerators
             il_converter = new NETGenerator.ILConverter(StandartDirectories);
 			il_converter.ConvertFromTree(ProgramTree, TargetFileName, SourceFileName, options, ResourceFiles);
 		}
+
+		public void EmitAssemblyRedirects(AssemblyResolveScope resolveScope, string outputFileName) =>
+			il_converter.EmitAssemblyRedirects(resolveScope, outputFileName);
 
 		public void Reset()
 		{

--- a/NETGenerator/NETGenerator.cs
+++ b/NETGenerator/NETGenerator.cs
@@ -15,6 +15,8 @@ using System.Runtime.Remoting;
 using System.Security;
 using System.Runtime.Versioning;
 using System.Text;
+using NETGenerator;
+using PascalABCCompiler.NetHelper;
 
 namespace PascalABCCompiler.NETGenerator
 {
@@ -1232,6 +1234,13 @@ namespace PascalABCCompiler.NETGenerator
             foreach (FileStream fs in ResStreams)
                 fs.Close();
 
+        }
+
+        public void EmitAssemblyRedirects(AssemblyResolveScope resolveScope, string targetAssemblyPath)
+        {
+            if (IsDotnet5() || IsDotnetNative()) return;
+            var appConfigPath = targetAssemblyPath + ".config";
+            AppConfigUtil.UpdateAppConfig(resolveScope.BindingRedirects, appConfigPath);
         }
 
         private void AddSpecialInitDebugCode()

--- a/NETGenerator/NETGenerator.cs
+++ b/NETGenerator/NETGenerator.cs
@@ -1,22 +1,22 @@
 // Copyright (c) Ivan Bondarev, Stanislav Mikhalkovich (for details please see \doc\copyright.txt)
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
+
 using System;
-using System.Linq;
-using PascalABCCompiler.SemanticTree;
-using System.Threading;
-using System.Reflection;
-using System.Reflection.Emit;
 using System.Collections;
 using System.Collections.Generic;
-using System.IO;
 using System.Diagnostics.SymbolStore;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
 using System.Runtime.InteropServices;
-using System.Runtime.Remoting;
-using System.Security;
 using System.Runtime.Versioning;
+using System.Security;
 using System.Text;
+using System.Threading;
 using NETGenerator;
 using PascalABCCompiler.NetHelper;
+using PascalABCCompiler.SemanticTree;
 
 namespace PascalABCCompiler.NETGenerator
 {
@@ -1240,7 +1240,7 @@ namespace PascalABCCompiler.NETGenerator
         {
             if (IsDotnet5() || IsDotnetNative()) return;
             var appConfigPath = targetAssemblyPath + ".config";
-            AppConfigUtil.UpdateAppConfig(resolveScope.BindingRedirects, appConfigPath);
+            AppConfigUtil.UpdateAppConfig(resolveScope.CalculateBindingRedirects(), appConfigPath);
         }
 
         private void AddSpecialInitDebugCode()

--- a/NETGenerator/NETGenerator.csproj
+++ b/NETGenerator/NETGenerator.csproj
@@ -129,11 +129,13 @@
       <Project>{1C9C945A-586D-42A2-A06B-65D84FA7FF78}</Project>
       <Name>TreeConverter</Name>
     </ProjectReference>
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Configuration\GlobalAssemblyInfo.cs">
       <Link>Config\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AppConfigUtil.cs" />
     <Compile Include="Config\AssemblyInfo.cs" />
     <Compile Include="NETGenegratorTools.cs" />
     <Compile Include="CodeGenerator.cs">


### PR DESCRIPTION
Теперь [пример с ML из замечаний к версии 3.9.0](https://pascalabcnet.github.io/mydoc_release_notes_3_9_0.html) компилируется и запускается без дополнительных действий. Для него генерируется такой конфигурационный файл:
```
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <runtime>
    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
      <dependentAssembly>
        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
      </dependentAssembly>
    </assemblyBinding>
  </runtime>
</configuration>
```

Это также соответствует поведению C# SDK, если ей на вход подать такой же набор NuGet-пакетов.

В процессе тестирования этой функции обнаружил интересный аспект поведения: случайно вышло так, что VisualPascalABCNET генерирует эти конфигурационные файлы инкрементально.

На каждую перекомпиляцию проекта мы подгружаем только новые сборки (которых ещё нет в application domain компилятора), и поэтому в список binding redirects попадают только они.

То есть, если удалить файл `<TargetAssemblyName>.config` между перекомпиляциями в IDE, можно получить нестабильный результат (не все binding redirects попадут в выходной файл). Пользователь может исправить эту проблему перезагрузкой IDE (после перезагрузки она снова сохранит _все_ binding redirects, а не только новые).

Кажется, что с практической точки зрения это поведение не слишком проблематично: во время обычной работы пользователь вряд ли удаляет этот конфигурационный файл. А если он последовательно добавляет новые ссылки в текущий проект, то они будут инкрементально догенерироваться в конфигурационном файле правильным образом.

Это поведение возможно улучшить (сохраняя список binding redirects и передавая его в новые экземпляры `AssemblyResolveScope` в сервисном процессе компилятора), но пока я предлагаю оставить это как есть, и переработать в рамках #2912, если пользователи не будут жаловаться.