### PR TITLE
Исправление бага на пересечении `IntRange` и комбинаторики

### DIFF
--- a/TestSuite/IntRange comb.pas
+++ b/TestSuite/IntRange comb.pas
@@ -1,0 +1,8 @@
+﻿##
+var r := 2..3;
+Assert(
+  r.Cartesian(2)
+//  .Println
+  .ZipTuple(||2,2|,|2,3|,|3,2|,|3,3||)
+  .All(\(a,b)->a.SequenceEqual(b))
+);

--- a/bin/Lib/PABCSystem.pas
+++ b/bin/Lib/PABCSystem.pas
@@ -685,7 +685,7 @@ type
     // https://referencesource.microsoft.com/#System.Core/System/Linq/Enumerable.cs,783a052330e7d48d,references
     
     public procedure CopyTo(a: array of integer; arrayIndex: integer) :=
-      for var i := 0 to System.Math.Min(self.Count, a.Length-arrayIndex) do
+      for var i := 0 to System.Math.Min(self.Count, a.Length-arrayIndex)-1 do
         a[i+arrayIndex] := l+i;
     
   end;
@@ -751,7 +751,7 @@ type
     end;
     
     public procedure CopyTo(a: array of char; arrayIndex: integer) :=
-      for var i := 0 to System.Math.Min(self.Count, a.Length-arrayIndex) do
+      for var i := 0 to System.Math.Min(self.Count, a.Length-arrayIndex)-1 do
         a[i+arrayIndex] := char(integer(l)+i);
     
   end;


### PR DESCRIPTION
Изначально было
```
      for var i := 0 to self.Count-1 do
```
Я оттестировал, но затем сделал чтобы массив результата не переполнялся:
```
      for var i := 0 to System.Math.Min(self.Count, a.Length-arrayIndex) do
```
И в итоге потерял `-1`...