### PR TITLE
Fix interfaces loop dependency check

### DIFF
--- a/TestSuite/usesunits/UsesInUnits6/A.pas
+++ b/TestSuite/usesunits/UsesInUnits6/A.pas
@@ -1,0 +1,9 @@
+﻿unit A;
+
+interface 
+
+uses B;
+
+implementation
+
+end.

--- a/TestSuite/usesunits/UsesInUnits6/B.pas
+++ b/TestSuite/usesunits/UsesInUnits6/B.pas
@@ -1,0 +1,9 @@
+﻿unit B;
+
+interface
+
+implementation
+
+uses C;
+
+end.

--- a/TestSuite/usesunits/UsesInUnits6/C.pas
+++ b/TestSuite/usesunits/UsesInUnits6/C.pas
@@ -1,0 +1,9 @@
+﻿unit C;
+
+interface
+
+uses uses_in6_cycle_with_implementation_dependency in '..\uses_in6_cycle_with_implementation_dependency';
+
+implementation
+
+end.

--- a/TestSuite/usesunits/uses_in6_cycle_with_implementation_dependency.pas
+++ b/TestSuite/usesunits/uses_in6_cycle_with_implementation_dependency.pas
@@ -1,0 +1,9 @@
+﻿unit uses_in6_cycle_with_implementation_dependency;
+
+interface
+
+uses A in 'UsesInUnits6\A';  
+
+implementation
+
+end.


### PR DESCRIPTION
Исправлен случай ложного возникновения ошибки циклической зависимости интерфейсов. В соответствующей ошибке проверке не была учтена возможность цикла с присутствующими в нем связями из implementation части.