### PR TITLE
`.AdjacentGroupBy` - `.AdjacentGroup` с функцией ключей

### DIFF
--- a/bin/Lib/PABCSystem.pas
+++ b/bin/Lib/PABCSystem.pas
@@ -11179,7 +11179,41 @@ begin
     yield c.TakeGroup().ToArray;
 end;
 
-// ToDo Сделать AdjacentGroup с функцией сравнения
+function AdjacentGroupBy<T,TKey>(self: sequence of T; by: T->TKey; comp: IEqualityComparer<TKey>): sequence of (TKey, array of T); extensionmethod;
+begin
+  var enmr := self.GetEnumerator;
+  if not enmr.MoveNext then exit;
+  if comp=nil then comp := System.Collections.Generic.EqualityComparer&<TKey>.Default;
+  
+  var l := new List<T>;
+  var key: TKey;
+  begin
+    var o := enmr.Current;
+    l += o;
+    key := by(o);
+  end;
+  var key_hc := comp.GetHashCode(key);
+  
+  while enmr.MoveNext do
+  begin
+    var o := enmr.Current;
+    var n_key := by(o);
+    var n_key_hc := comp.GetHashCode(n_key);
+    
+    if (n_key_hc<>key_hc) or not comp.Equals(n_key, key) then
+    begin
+      yield (key, l.ToArray);
+      l.Clear;
+      key := n_key;
+      key_hc := n_key_hc;
+    end;
+    
+    l += o;
+  end;
+  
+  yield (key, l.ToArray);
+end;
+function AdjacentGroupBy<T,TKey>(self: sequence of T; by: T->TKey); extensionmethod := self.AdjacentGroupBy(by, nil);
 
 /// Возвращает количество элементов, равных указанному значению
 function CountOf<T>(Self: sequence of T; x: T): integer; extensionmethod;

--- a/bin/Lib/PABCSystem.pas
+++ b/bin/Lib/PABCSystem.pas
@@ -11179,6 +11179,8 @@ begin
     yield c.TakeGroup().ToArray;
 end;
 
+/// Группирует подряд идущие элементы с одинаковыми значениями ключами
+/// Использует компаратор comp
 function AdjacentGroupBy<T,TKey>(self: sequence of T; by: T->TKey; comp: IEqualityComparer<TKey>): sequence of (TKey, array of T); extensionmethod;
 begin
   var enmr := self.GetEnumerator;
@@ -11213,6 +11215,8 @@ begin
   
   yield (key, l.ToArray);
 end;
+/// Группирует подряд идущие элементы с одинаковыми значениями ключами
+/// Использует компаратор по-умолчанию
 function AdjacentGroupBy<T,TKey>(self: sequence of T; by: T->TKey); extensionmethod := self.AdjacentGroupBy(by, nil);
 
 /// Возвращает количество элементов, равных указанному значению


### PR DESCRIPTION
Давно этой штуки не хватает.
Сейчас в очередной раз столкнулся с этим: https://www.cyberforum.ru/pascalabc-net/thread3162814.html

Вообще я никогда не понимал где может использоваться оригинальный `.AdjacentGroup`.
Он возвращает массив из кучи одинаковых значений - с тем же успехом можно было бы возвращать `(item, count)` вместо массива. Но мне и такой функционал ни разу не пригодился - а вот группировка по ключу много где нужна была.