### PR TITLE
Исправление состояния гонки при запуске `GraphABC` на некоторых линуксах

### DIFF
--- a/bin/Lib/GraphABC.pas
+++ b/bin/Lib/GraphABC.pas
@@ -1305,7 +1305,6 @@ var
   x_coord, y_coord: integer;
   NotLockDrawing: boolean;
   
-  StartIsComplete: boolean;
   MainFormThread: System.Threading.Thread;
   
   // coords for write 
@@ -4207,7 +4206,6 @@ end;
 procedure InitForm0;
 begin
   InitForm;
-  StartIsComplete := True;
   Application.Run(MainForm);
 end;
 
@@ -4218,12 +4216,13 @@ begin
   sf.FormatFlags := StringFormatFlags.MeasureTrailingSpaces;
   firstcall := False;
   clMoneyGreen := RGB(192, 220, 192);
-  StartIsComplete := False;
   MainFormThread := new System.Threading.Thread(InitForm0);
   MainFormThread.Start;
-  while not StartIsComplete do
-    Sleep(30);
-  Sleep(30);
+  
+  var StartIsComplete := false;
+  MainForm.Shown += (o,e)->(StartIsComplete := true);
+  while not StartIsComplete do Sleep(1);
+  
   SetSmoothingOn;
   _GraphABCControl := f;
   CurrentIOSystem := new IOGraphABCSystem;

--- a/bin/Lib/GraphABC.pas
+++ b/bin/Lib/GraphABC.pas
@@ -1305,6 +1305,7 @@ var
   x_coord, y_coord: integer;
   NotLockDrawing: boolean;
   
+  StartIsComplete: boolean;
   MainFormThread: System.Threading.Thread;
   
   // coords for write 
@@ -4206,6 +4207,7 @@ end;
 procedure InitForm0;
 begin
   InitForm;
+  MainForm.Shown += (o,e)->(StartIsComplete := true);
   Application.Run(MainForm);
 end;
 
@@ -4216,11 +4218,10 @@ begin
   sf.FormatFlags := StringFormatFlags.MeasureTrailingSpaces;
   firstcall := False;
   clMoneyGreen := RGB(192, 220, 192);
+  StartIsComplete := False;
   MainFormThread := new System.Threading.Thread(InitForm0);
   MainFormThread.Start;
   
-  var StartIsComplete := false;
-  MainForm.Shown += (o,e)->(StartIsComplete := true);
   while not StartIsComplete do Sleep(1);
   
   SetSmoothingOn;


### PR DESCRIPTION
`StartIsComplete` ставило до запуска формы, а не после него. Но затем ожидало дополнительные 30мс перед тем как продолжать. Это костыль - надо следить за ивентом вроде `.Shown`, как я сделал тут.

Пока драфт, потому что надо тестить.