### PR TITLE
Исправление `TypeToTypeName` для энумов

### DIFF
--- a/TestSuite/ObjectToString.pas
+++ b/TestSuite/ObjectToString.pas
@@ -23,6 +23,7 @@ begin
   Test(1);
   Test('abc');
   Test(new System.UIntPtr(123));
+  Test(System.ConsoleColor.Cyan);
   
   Test(new byte[2,1,1,1,1,1,1,1,2]);
   Test(new byte[2,1,1,1,0,1,1,1,2]);

--- a/TestSuite/ObjectToString.txt
+++ b/TestSuite/ObjectToString.txt
@@ -1,6 +1,7 @@
 ﻿integer{ 1 }
 string{ abc }
 UIntPtr{ 123 }
+ConsoleColor{ Cyan }
 array[,,,,,,,,] of byte{ [[[[[[[[[0,0]]]]]]]],[[[[[[[[0,0]]]]]]]]] }
 array[,,,,,,,,] of byte{ [] }
 List<real>{ [1.2,3] }

--- a/TestSuite/tttn1.pas
+++ b/TestSuite/tttn1.pas
@@ -1,0 +1,3 @@
+﻿##
+var tn := TypeToTypeName(typeof(System.ConsoleColor));
+Assert(tn = 'ConsoleColor');

--- a/TestSuite/tttn1.pas
+++ b/TestSuite/tttn1.pas
@@ -1,3 +1,0 @@
-﻿##
-var tn := TypeToTypeName(typeof(System.ConsoleColor));
-Assert(tn = 'ConsoleColor');


### PR DESCRIPTION
```
## TypeToTypeName(typeof(System.ConsoleColor)).Println;
```
Сейчас это выводит `integer`.

`Type.GetTypeCode` работает по-особому с энумами:
https://learn.microsoft.com/en-us/dotnet/api/system.type.gettypecode?view=net-8.0#remarks
Поэтому его надо отдельно обрабатывать, чтобы энумы правильно выводило.