### PR TITLE
Исправление #3116

### DIFF
--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -2739,16 +2739,19 @@ namespace PascalABCCompiler
 
             if (!PCUFileNamesDictionary.TryGetValue(cacheKey, out var fileNameWithPriority))
             {
-                if (FindFileWithExtensionInDirs(fileName, out _, currentPath) is string resultFileName1)
+                if (Path.GetExtension(fileName) != CompilerOptions.CompiledUnitExtension)
+                    fileNameWithPriority = null;
+
+                else if (FindFileWithExtensionInDirs(fileName, out _, currentPath) is string resultFileName1)
                     fileNameWithPriority = Tuple.Create(resultFileName1, 1);
-                else if (FindFileWithExtensionInDirs(Path.GetFileName(fileName), out _, CompilerOptions.OutputDirectory) is string resultFileName2)
+                else if (CompilerOptions.OutputDirectory != project.Path && FindFileWithExtensionInDirs(Path.GetFileName(fileName), out _, CompilerOptions.OutputDirectory) is string resultFileName2)
                     fileNameWithPriority = Tuple.Create(resultFileName2, 2);
                 else if (FindFileWithExtensionInDirs(fileName, out var dirIndex, CompilerOptions.SearchDirectories.ToArray()) is string resultFileName3)
                     fileNameWithPriority = Tuple.Create(resultFileName3, 3 + dirIndex);
                 else
                     fileNameWithPriority = null;
 
-                PCUFileNamesDictionary[cacheKey] = fileNameWithPriority;
+				PCUFileNamesDictionary[cacheKey] = fileNameWithPriority;
             }
 
             folderPriority = fileNameWithPriority?.Item2 ?? 0;
@@ -2760,8 +2763,9 @@ namespace PascalABCCompiler
             var cacheKey = Tuple.Create(fileName.ToLower(), currentPath?.ToLower());
 
             if (!SourceFileNamesDictionary.TryGetValue(cacheKey, out var fileNameWithPriority))
-            {
-                if (FindSourceFileNameInDirs(fileName, out _, currentPath) is string resultFileName1)
+			{
+
+				if (FindSourceFileNameInDirs(fileName, out _, currentPath) is string resultFileName1)
                     fileNameWithPriority = Tuple.Create(resultFileName1, 1);
                 else if (FindSourceFileNameInDirs(fileName, out var dirIndex, CompilerOptions.SearchDirectories.ToArray()) is string resultFileName2)
                     fileNameWithPriority = Tuple.Create(resultFileName2, 3 + dirIndex);

--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -2744,7 +2744,7 @@ namespace PascalABCCompiler
 
                 else if (FindFileWithExtensionInDirs(fileName, out _, currentPath) is string resultFileName1)
                     fileNameWithPriority = Tuple.Create(resultFileName1, 1);
-                else if (CompilerOptions.OutputDirectory != project.Path && FindFileWithExtensionInDirs(Path.GetFileName(fileName), out _, CompilerOptions.OutputDirectory) is string resultFileName2)
+                else if (CompilerOptions.OutputDirectory != CompilerOptions.SourceFileDirectory && FindFileWithExtensionInDirs(Path.GetFileName(fileName), out _, CompilerOptions.OutputDirectory) is string resultFileName2)
                     fileNameWithPriority = Tuple.Create(resultFileName2, 2);
                 else if (FindFileWithExtensionInDirs(fileName, out var dirIndex, CompilerOptions.SearchDirectories.ToArray()) is string resultFileName3)
                     fileNameWithPriority = Tuple.Create(resultFileName3, 3 + dirIndex);


### PR DESCRIPTION
fix #3116

Там наложилось 2 проблемы:

1. Функция `FindPCUFileName` могла найти `.pas` файлы - если указать расширение (.pas) файла в `uses-in`
2. `CompilerOptions.OutputDirectory` использовалось даже если оно не было установлено (опция "Генерировать выходные файлы в папку" в редакторе. по-умолчанию папка Output). В таком случае .pcu брало из папки с основным .pas файлом программы.