### PR TITLE
Fix directives format null bug

### DIFF
--- a/Parsers/PascalABCParserNewSaushkin/ABCPascalParserTools.cs
+++ b/Parsers/PascalABCParserNewSaushkin/ABCPascalParserTools.cs
@@ -127,7 +127,8 @@ namespace PascalABCSavParser
             // подстрока с параметрами
             string paramsString = directiveText.Substring(directiveText.IndexOf(directiveName) + directiveName.Length);
             
-            if (ParserCached.ValidDirectives[directiveName].quotesAreSpecialSymbols)
+            // если кавычки используются как специальные символы (для объединения нескольких слов в одно)
+            if (ParserCached.ValidDirectives[directiveName] != null && ParserCached.ValidDirectives[directiveName].quotesAreSpecialSymbols)
             {
                 directiveParams = SplitDirectiveParamsWithQuotesAsSpecialSymbols(paramsString);
             }


### PR DESCRIPTION
Исправлена ошибка NullReferenceException в ParseDirective для директивы без параметров.