### PR TITLE
Синхронилировал поведение `.ToLines` со стандартными типами .Net, как `System.IO.StringReader`

### DIFF
--- a/bin/Lib/PABCSystem.pas
+++ b/bin/Lib/PABCSystem.pas
@@ -13758,7 +13758,18 @@ end;
 /// Преобразует многострочную строку в массив строк
 function ToLines(Self: string): array of string; extensionmethod;
 begin
-  Result := Self.Split(|NewLine|, System.StringSplitOptions.None);
+  Result := Self.Split(|
+    #13#10, // CR+LF: Win
+    #10, // LF: Linux
+    #13 // CR: Mac
+    // https://en.m.wikipedia.org/wiki/Newline#Unicode
+    // But standard .Net things like System.IO.StringReader don't support these, so for now - commented out
+//    #11, // Vertical Tab
+//    #12, // Form feed
+//    char($85), // Next Line
+//    char($2028), // Line Separator
+//    char($2029), // Paragraph SeparatorS
+  |, System.StringSplitOptions.None);
 end;
 
 procedure PassSpaces(var s: string; var from: integer); 


### PR DESCRIPTION
https://t.me/c/1773182219/4249
Тут указали на полные список юникодных символов:
https://en.m.wikipedia.org/wiki/Newline#Unicode
А в текущей реализации `.ToLines` - оно вообще не может обработать текстовые файлы созданные на одной ОС, но прочитанные на другой.

Существующие в стадартных библиотеках .Net методы ведут себя так:
```
## var r := new System.IO.StringReader('a'#13#10'b'#10'c'#13'd'#11'e'#12'f'+char($0085)+'g'+char($2028)+'h'+char($2029)+'i');

while true do
begin
  var l := r.ReadLine;
  if l=nil then break;
  $'[{l}] = {ObjectToString(l.Select(ch->''$''+ch.Code.ToString(''X'')))}'.Println;
end;
```
```
[a] = [$61]
[b] = [$62]
[c] = [$63]
[d
efg
h
i] = [$64,$B,$65,$C,$66,$85,$67,$2028,$68,$2029,$69]
```
И в Net8.0 Так же:
```
var r = new StringReader("a\r\nb\nc\rd\ve\ff\u0085g\u2028h\u2029i");
while (true)
{
	var l = r.ReadLine();
	if (l == null) break;
	Console.WriteLine($"[{l}] = [{string.Join(',', l.Select(ch=>"0x"+((int)ch).ToString("X")))}]");
}
```
```
[a] = [0x61]
[b] = [0x62]
[c] = [0x63]
[defg h i] = [0x64,0xB,0x65,0xC,0x66,0x85,0x67,0x2028,0x68,0x2029,0x69]
```
(только консоль VS по-другому их прочитала, но обработало так же)

Первые 3 распознаёт как переносы строк, остальные юникодные символы - нет.
В этом PR сделал чтобы `.ToLines` вело себя так же.