### PR TITLE
Исправление копирования .dll в `GetReferenceFileName`

### DIFF
--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -2903,9 +2903,9 @@ namespace PascalABCCompiler
             try
             {
                 var FullFileName = Path.Combine(curr_path, FileName);
-                if (System.IO.File.Exists(FullFileName))
+                if (File.Exists(FullFileName))
                 {
-                    var NewFileName = Path.Combine(CompilerOptions.OutputDirectory, Path.GetFileName(FullFileName));
+                    var NewFileName = Path.GetFullPath(Path.Combine(CompilerOptions.OutputDirectory, Path.GetFileName(FullFileName)));
                     if (FullFileName != NewFileName)
                     {
                         if (overwrite)


### PR DESCRIPTION
`OutputDirectory` не всегда полный путь. К примеру если вызвать `pabcnetcclear .\a.pas`, `OutputDirectory` оказывается `.\`
Я не нашёл чтобы от этого ещё что то ломалось, только .dll в этой же папке лишний раз копирует поверх самой себя. С этим пулом больше не копирует.