### PR TITLE
Исправление зависимостей проектов

### DIFF
--- a/.github/workflows/build_separate_proj.yml
+++ b/.github/workflows/build_separate_proj.yml
@@ -1,0 +1,56 @@
+﻿name: Build all C# projects separately
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  
+  release:
+    types:
+      - created
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare_matrix:
+    runs-on: windows-2019
+    outputs:
+      projects: ${{ steps.set_outputs.outputs.projects }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Get all.csproj files
+        id: set_outputs
+        run: |
+        
+          $projects = Get-ChildItem -Recurse '*.csproj' | ForEach-Object { $_.FullName }
+          $json = $projects | ConvertTo-Json -Compress
+          Write-Host $json
+          echo "::set-output name=projects::$json"
+  
+  build-and-test:
+    runs-on: windows-2019
+    needs: prepare_matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ${{ fromJson(needs.prepare_matrix.outputs.projects) }}
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Run tests for each project
+        run: |
+        
+          $project = "${{ matrix.project }}"
+          .\Studio.bat $project
+          
+          $pname = [IO.Path]::GetFileNameWithoutExtension($project)
+          if ($pname -eq 'PABCNETCclear') {
+            '##' | Set-Content 'a.pas'
+            &".\bin\$pname.exe" .\a.pas
+          }

--- a/Compiler/Compiler.csproj
+++ b/Compiler/Compiler.csproj
@@ -161,6 +161,16 @@
       <Project>{1C9C945A-586D-42A2-A06B-65D84FA7FF78}</Project>
       <Package>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</Package>
     </ProjectReference>
+    <ProjectReference Include="..\Languages\Pascal\PascalLanguage\PascalLanguage.csproj">
+      <Name>PascalLanguage</Name>
+      <Project>{BD902586-E0D5-407A-904A-32249B8B709E}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="..\Languages\Pascal\PascalABCParserNewSaushkin\PascalABCSaushkinParser.csproj">
+      <Name>PascalABCSaushkinParser</Name>
+      <Project>{1443F539-DCC7-4491-B4FD-B716C739DB3C}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Compiler.cs" />

--- a/VisualPascalABCNET/VisualPascalABCNET.csproj
+++ b/VisualPascalABCNET/VisualPascalABCNET.csproj
@@ -856,6 +856,11 @@
       <Project>{857CA1A3-FC88-4BE0-AB6A-D1EE772AB288}</Project>
       <Name>ICSharpCode.Core.WinForms</Name>
     </ProjectReference>
+    <ProjectReference Include="..\pabcnetc\PABCNETC.csproj">
+      <Name>PABCNETC</Name>
+      <Project>{2aef58a1-2bcf-4c4b-ab03-f44bbb2628e6}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/VisualPascalABCNET/VisualPascalABCNET_40.csproj
+++ b/VisualPascalABCNET/VisualPascalABCNET_40.csproj
@@ -850,6 +850,11 @@
       <Project>{857CA1A3-FC88-4BE0-AB6A-D1EE772AB288}</Project>
       <Name>ICSharpCode.Core.WinForms</Name>
     </ProjectReference>
+    <ProjectReference Include="..\pabcnetc\PABCNETC.csproj">
+      <Name>PABCNETC</Name>
+      <Project>{2aef58a1-2bcf-4c4b-ab03-f44bbb2628e6}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/VisualPascalABCNETLinux/VisualPascalABCNETLinux.csproj
+++ b/VisualPascalABCNETLinux/VisualPascalABCNETLinux.csproj
@@ -958,6 +958,11 @@
       <Project>{a9ab4282-83b4-41a7-86c3-e5bf6a45e7e2}</Project>
       <Name>SyntaxVisitors</Name>
     </ProjectReference>
+    <ProjectReference Include="..\pabcnetc\PABCNETC.csproj">
+      <Name>PABCNETC</Name>
+      <Project>{2aef58a1-2bcf-4c4b-ab03-f44bbb2628e6}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">


### PR DESCRIPTION
Компилятор использует `PascalLanguage` и `PascalABCParserNewSaushkin` как языковой плагин, то есть .dll-ки этих 2 проектов подгружаются из компилятора.
И компилятор ожидает что их содержимое будет соответствовать версии исходников, к примеру после прыжка между ветками, или даже просто после выполнения `git pull`.
Но в то же время эти 2 проекта подгружаются как плагины, их типы не должны быть напрямую видны из компилятора.

Поэтому я добавил их в зависимости, но с
```
      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
```
Таким образом их пересобирает вместе с компилятором, если что то поменялось (или если они небыли созданы ещё)

---

Так же, первым коммитом добавил новый workflow, проверяющий что все проекты можно собрать отдельно.

Для проекта `PABCNETCclear` там особая проверка, пытающаяся сразу его использовать.
До второго коммита эта проверка падала вот так:
https://github.com/SunSerega/pascalabcnet/actions/runs/9735163926/job/26864067758#step:3:557
```
Compile errors:
Can not choose parser for file 'a.pas'
Error: Process completed with exit code 1.
```
А для второго коммита эта проверка уже проходит - потому что он добавляет собственно зависимости, таким образом .dll плагина создаётся и компилятор уже может успешно выбрать парсер для .pas файла, без полного ребилда.

---

И тетий коммит добавил `PABCNETC` в зависимости проектов IDE.

Теперь можно клонировать проект в новую папку, открыть .sln файл и запустить там IDE из студии, без ребилда. Студия сама собирёт все необходимые проекты.