### PR TITLE
Symbol table resetting for intellisense in debug mode

### DIFF
--- a/TreeConverter/SymbolTable/DSST/SymbolTable.cs
+++ b/TreeConverter/SymbolTable/DSST/SymbolTable.cs
@@ -640,7 +640,7 @@ namespace SymbolTable
         #region DSSymbolTable(int hash_size,bool case_sensitive)
         public DSSymbolTable(int hash_size,bool case_sensitive)
 		{
-            CaseSensitive = case_sensitive;
+            // CaseSensitive = case_sensitive;
             Clear();
         }
 		#endregion

--- a/TreeConverter/TreeConversion/convertion_data_and_alghoritms.cs
+++ b/TreeConverter/TreeConversion/convertion_data_and_alghoritms.cs
@@ -27,10 +27,6 @@ namespace PascalABCCompiler.TreeConverter
 
 		public convertion_data_and_alghoritms(syntax_tree_visitor stv)
 		{
-#if DEBUG
-            if (stv.for_intellisense)
-                symbolTable = new SymbolTable.TreeConverterSymbolTable();
-#endif
             type_table.type_table_function_call_maker = create_simple_function_call;
 			_stv=stv;
             _type_constructor = new type_constructor(this);

--- a/TreeConverter/TreeConversion/convertion_data_and_alghoritms.cs
+++ b/TreeConverter/TreeConversion/convertion_data_and_alghoritms.cs
@@ -27,8 +27,10 @@ namespace PascalABCCompiler.TreeConverter
 
 		public convertion_data_and_alghoritms(syntax_tree_visitor stv)
 		{
+#if DEBUG
             if (stv.for_intellisense)
                 symbolTable = new SymbolTable.TreeConverterSymbolTable();
+#endif
             type_table.type_table_function_call_maker = create_simple_function_call;
 			_stv=stv;
             _type_constructor = new type_constructor(this);

--- a/TreeConverter/TreeConversion/convertion_data_and_alghoritms.cs
+++ b/TreeConverter/TreeConversion/convertion_data_and_alghoritms.cs
@@ -13,9 +13,9 @@ namespace PascalABCCompiler.TreeConverter
 
 	public class convertion_data_and_alghoritms
 	{
-		internal SymbolTable.TreeConverterSymbolTable symtab=SymbolTable.SymbolTableController.CurrentSymbolTable;
+        private SymbolTable.TreeConverterSymbolTable symbolTable = SymbolTable.SymbolTableController.CurrentSymbolTable;
 
-		private PascalABCCompiler.Errors.SyntaxError _parser_error;
+    	private PascalABCCompiler.Errors.SyntaxError _parser_error;
 
 		private syntax_tree_visitor _stv;
 
@@ -27,6 +27,8 @@ namespace PascalABCCompiler.TreeConverter
 
 		public convertion_data_and_alghoritms(syntax_tree_visitor stv)
 		{
+            if (stv.for_intellisense)
+                symbolTable = new SymbolTable.TreeConverterSymbolTable();
             type_table.type_table_function_call_maker = create_simple_function_call;
 			_stv=stv;
             _type_constructor = new type_constructor(this);
@@ -58,7 +60,7 @@ namespace PascalABCCompiler.TreeConverter
 
 		public void reset()
 		{
-			symtab.Clear();
+			symbol_table.Clear();
             _type_constructor.reset();
             statement_list_stack.clear();
             arr_nums = 0;
@@ -131,7 +133,7 @@ namespace PascalABCCompiler.TreeConverter
 		{
 			get
 			{
-				return symtab;
+                return symbolTable;
 			}
 		}
 
@@ -487,7 +489,7 @@ namespace PascalABCCompiler.TreeConverter
                     {
                         common_in_function_function_node cffn = (common_in_function_function_node)fn;
                         common_in_function_function_call cffc = new common_in_function_function_call(cffn,
-                            symtab.GetRelativeScopeDepth(cffn.function.scope, top_function.scope), loc);
+                            symbol_table.GetRelativeScopeDepth(cffn.function.scope, top_function.scope), loc);
                         cffc.parameters.AddRange(exprs);
                         expr_node = cffc;
                         break;

--- a/TreeConverter/TreeConversion/syntax_tree_visitor.cs
+++ b/TreeConverter/TreeConversion/syntax_tree_visitor.cs
@@ -155,7 +155,7 @@ namespace PascalABCCompiler.TreeConverter
             ErrorsList = initializationData.errorsList;
             WarningsList = initializationData.warningsList;
 
-            SymbolTable.CaseSensitive = SemanticRulesConstants.SymbolTableCaseSensitive;
+            // SymbolTable.CaseSensitive = SemanticRulesConstants.SymbolTableCaseSensitive;
 
             this.debug = initializationData.debug;
             this.debugging = initializationData.debugging;


### PR DESCRIPTION
Закомментировано ненужное поле CaseSensitive в классе таблицы символов. Оно не использовалось, использовалось CaseSensitive из Scope, и это верно для таблицы символов, содержащей в себе данные из разных языков.

Ведутся работы для облегчением дебаггинга интеллисенса.