### PR TITLE
Create default syntax tree converter class

### DIFF
--- a/SyntaxVisitors/BaseSyntaxTreeConverter.cs
+++ b/SyntaxVisitors/BaseSyntaxTreeConverter.cs
@@ -22,4 +22,12 @@ namespace PascalABCCompiler.SyntaxTreeConverters
 
         protected abstract syntax_tree_node ApplyConcreteConversions(syntax_tree_node root);
     }
+
+    
+    public class DefaultSyntaxTreeConverter : BaseSyntaxTreeConverter
+    {
+        public override string Name => "Default";
+
+        protected override syntax_tree_node ApplyConcreteConversions(syntax_tree_node root) => root;
+    }
 }


### PR DESCRIPTION
Для удобства разработчиков простых языков, которым не требуются дополнительные обходы синтаксического дерева добавлен дефолтный конвертор, реализующий абстрактный класс BaseSyntaxTreeConverter.