### PR TITLE
Исправление NRE в `TypeName`

### DIFF
--- a/bin/Lib/PABCSystem.pas
+++ b/bin/Lib/PABCSystem.pas
@@ -4819,7 +4819,7 @@ begin
     exit;
   end;
   
-  if t.FullName.StartsWith('PABCSystem.NewSet`1') then
+  if t.IsGenericType and (t.GetGenericTypeDefinition = typeof(NewSet<>)) then
   begin
     res.Write('set of ');
     TypeToTypeNameHelper(t.GetGenericArguments.Single, res);


### PR DESCRIPTION
`t.FullName` может быть `nil`:
```
Print( typeof(System.Nullable<>).GetGenericArguments.Single.FullName );
```
Поэтому новый код для `NewSet<>` у меня падал при сборке POCGL.
Исправление протестил - теперь всё собирается.