### PR TITLE
Intellisense memory leaks fix

### DIFF
--- a/CodeCompletion/CodeCompletion.cs
+++ b/CodeCompletion/CodeCompletion.cs
@@ -417,7 +417,7 @@ namespace CodeCompletion
     	public static string GetModifiedProgramm(string src)
     	{
     		sb.Remove(0,sb.Length);
-    		if (!src.EndsWith("end."))
+    		if (!src.TrimEnd().EndsWith("end."))
     		{
     			sb.AppendLine(src);
     			sb.AppendLine();

--- a/CodeCompletion/CodeCompletion.cs
+++ b/CodeCompletion/CodeCompletion.cs
@@ -124,6 +124,10 @@ namespace CodeCompletion
                 File.AppendAllText("log.txt", e.Message + Environment.NewLine + e.StackTrace + Environment.NewLine);
 #endif
             }
+
+            // очистка кэша и данных от старых компиляций, чтобы при новой компиляции не появились ссылки на старые данные
+            TypeTable.Clear();
+
             DomConverter dconv = new DomConverter(this);
             if (cu != null)
             {

--- a/CodeCompletion/TypeTable.cs
+++ b/CodeCompletion/TypeTable.cs
@@ -1,15 +1,8 @@
 ﻿// Copyright (c) Ivan Bondarev, Stanislav Mikhalkovich (for details please see \doc\copyright.txt)
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Text;
-using System.IO;
-using PascalABCCompiler.SyntaxTree;
-using System.Reflection;
 using PascalABCCompiler;
-using PascalABCCompiler.TreeConverter;
-using PascalABCCompiler.TreeRealization;
 using PascalABCCompiler.Parsers;
 
 namespace CodeCompletion
@@ -33,7 +26,9 @@ namespace CodeCompletion
         public static CompiledScope obj_type;
         public static CompiledScope void_type;
         private static Dictionary<Type, CompiledScope> type_cache = new Dictionary<Type, CompiledScope>();
-        
+
+        private static readonly CompiledScope[] standardTypes;
+
         private static ProcScope int_plus;
         private static ProcScope int_minus;
         private static ProcScope int_mul;
@@ -132,6 +127,14 @@ namespace CodeCompletion
         public static void Clear()
         {
         	type_cache.Clear();
+
+            // методы расширения добавляются при компиляции и, если их не очищать,
+            // то они могут содержать ссылки на неактуальные Scope с прошлых запусков Intellisence,
+            // то есть это потенциальные утечки памяти EVA
+            foreach (var type in standardTypes)
+            {
+                type.extension_methods?.Clear();
+            }
         }
 
         static TypeTable()
@@ -1049,6 +1052,26 @@ namespace CodeCompletion
             ps.AddParameter(left);
             ps.AddParameter(right);
             string_type.AddName(StringConstants.greq_name, ps);
+
+            standardTypes = new CompiledScope[]
+            {
+                int_type,
+                real_type,
+                string_type,
+                bool_type,
+                char_type,
+                byte_type,
+                float_type,
+                sbyte_type,
+                int16_type,
+                int64_type,
+                uint16_type,
+                uint32_type,
+                uint64_type,
+                ptr_type,
+                obj_type,
+                void_type
+            };
         }
 
         public static CompiledScope get_compiled_type(Type t)

--- a/VisualPascalABCNET/IB/CodeCompletion/CodeCompletionParserController.cs
+++ b/VisualPascalABCNET/IB/CodeCompletion/CodeCompletionParserController.cs
@@ -149,9 +149,8 @@ namespace VisualPascalABC
                 bool is_comp = false;
                 foreach (string FileName in open_files.Keys)
                 {
-                    //(ssyy) 18.05.08 Вставил проверку на null
-                    object o = open_files[FileName];
-                    if (o != null && (bool)o == true)
+
+                    if (open_files[FileName])
                     {
                         is_comp = true;
                         CodeCompletion.CodeCompletionController controller = new CodeCompletion.CodeCompletionController();

--- a/VisualPascalABCNET/IB/CodeCompletion/CodeCompletionParserController.cs
+++ b/VisualPascalABCNET/IB/CodeCompletion/CodeCompletionParserController.cs
@@ -164,6 +164,10 @@ namespace VisualPascalABC
                         if (string.IsNullOrEmpty(text))
                             text = "begin end.";
                         CodeCompletion.DomConverter tmp = CodeCompletion.CodeCompletionController.comp_modules[FileName] as CodeCompletion.DomConverter;
+
+                        // очистка кэша и данных от старых компиляций, чтобы при новой компиляции не появились ссылки на старые данные
+                        CodeCompletion.TypeTable.Clear();
+
                         long cur_mem = Environment.WorkingSet;
                         CodeCompletion.DomConverter dc = controller.Compile(FileName, text);
                         mem_delta += Environment.WorkingSet - cur_mem;
@@ -219,6 +223,10 @@ namespace VisualPascalABC
                                         CodeCompletion.CodeCompletionController controller = new CodeCompletion.CodeCompletionController();
                                         string text = visualEnvironmentCompiler.SourceFilesProvider(FileName, PascalABCCompiler.SourceFileOperation.GetText) as string;
                                         CodeCompletion.DomConverter tmp = CodeCompletion.CodeCompletionController.comp_modules[FileName] as CodeCompletion.DomConverter;
+
+                                        // очистка кэша и данных от старых компиляций, чтобы при новой компиляции не появились ссылки на старые данные
+                                        CodeCompletion.TypeTable.Clear();
+
                                         long cur_mem = Environment.WorkingSet;
                                         dc = controller.Compile(FileName, text);
                                         mem_delta += Environment.WorkingSet - cur_mem;
@@ -252,10 +260,7 @@ namespace VisualPascalABC
                     GC.Collect();
                 }
             }
-            catch (Exception e)
-            {
-
-            }
+            catch (Exception) { }
 
         }
 

--- a/VisualPascalABCNET/IB/CodeCompletion/CodeCompletionParserController.cs
+++ b/VisualPascalABCNET/IB/CodeCompletion/CodeCompletionParserController.cs
@@ -158,10 +158,6 @@ namespace VisualPascalABC
                         if (string.IsNullOrEmpty(text))
                             text = "begin end.";
                         CodeCompletion.DomConverter tmp = CodeCompletion.CodeCompletionController.comp_modules[FileName] as CodeCompletion.DomConverter;
-
-                        // очистка кэша и данных от старых компиляций, чтобы при новой компиляции не появились ссылки на старые данные
-                        CodeCompletion.TypeTable.Clear();
-
                         long cur_mem = Environment.WorkingSet;
                         CodeCompletion.DomConverter dc = controller.Compile(FileName, text);
                         mem_delta += Environment.WorkingSet - cur_mem;
@@ -217,10 +213,6 @@ namespace VisualPascalABC
                                         CodeCompletion.CodeCompletionController controller = new CodeCompletion.CodeCompletionController();
                                         string text = visualEnvironmentCompiler.SourceFilesProvider(FileName, PascalABCCompiler.SourceFileOperation.GetText) as string;
                                         CodeCompletion.DomConverter tmp = CodeCompletion.CodeCompletionController.comp_modules[FileName] as CodeCompletion.DomConverter;
-
-                                        // очистка кэша и данных от старых компиляций, чтобы при новой компиляции не появились ссылки на старые данные
-                                        CodeCompletion.TypeTable.Clear();
-
                                         long cur_mem = Environment.WorkingSet;
                                         dc = controller.Compile(FileName, text);
                                         mem_delta += Environment.WorkingSet - cur_mem;

--- a/VisualPascalABCNET/IB/CodeCompletion/CodeCompletionParserController.cs
+++ b/VisualPascalABCNET/IB/CodeCompletion/CodeCompletionParserController.cs
@@ -3,6 +3,7 @@
 using Languages.Integration;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace VisualPascalABC
 {
@@ -10,7 +11,7 @@ namespace VisualPascalABC
 
     public class CodeCompletionParserController : VisualPascalABCPlugins.ICodeCompletionService
     {
-        public static Hashtable open_files = new Hashtable(StringComparer.OrdinalIgnoreCase);
+        public static Dictionary<string, bool> open_files = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         public VisualEnvironmentCompiler visualEnvironmentCompiler;
         private System.Threading.Thread th = null;
         private CodeCompletionProvider ccp;
@@ -84,8 +85,7 @@ namespace VisualPascalABC
         {
             if (CodeCompletion.CodeCompletionController.comp_modules[FileName] != null)
                 CodeCompletion.CodeCompletionController.comp_modules.Remove(FileName);
-            if (open_files[FileName] != null)
-                open_files.Remove(FileName);
+            open_files.Remove(FileName);
         }
 
         public void SetAsChanged(string FileName)
@@ -98,17 +98,13 @@ namespace VisualPascalABC
         {
             try
             {
-                Hashtable open_files2 = open_files.Clone() as Hashtable;
-                foreach (string s in open_files2.Keys)
+                foreach (string s in open_files.Keys)
                 {
                     if (ProjectFactory.Instance.CurrentProject.ContainsSourceFile(s))
                         open_files[s] = true;
                 }
             }
-            catch (Exception e)
-            {
-
-            }
+            catch (Exception) { }
         }
 
         /// <summary>
@@ -149,10 +145,9 @@ namespace VisualPascalABC
         {
             try
             {
-                Hashtable open_files2 = (Hashtable)open_files.Clone();
-                Hashtable recomp_files = new Hashtable(StringComparer.OrdinalIgnoreCase);
+                Dictionary<string, string> recomp_files = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 bool is_comp = false;
-                foreach (string FileName in open_files2.Keys)
+                foreach (string FileName in open_files.Keys)
                 {
                     //(ssyy) 18.05.08 Вставил проверку на null
                     object o = open_files[FileName];
@@ -191,7 +186,7 @@ namespace VisualPascalABC
                             CodeCompletion.CodeCompletionController.comp_modules[FileName] = dc;
                     }
                 }
-                foreach (string FileName in open_files2.Keys)
+                foreach (string FileName in open_files.Keys)
                 {
                     CodeCompletion.DomConverter dc = CodeCompletion.CodeCompletionController.comp_modules[FileName] as CodeCompletion.DomConverter;
                     CodeCompletion.SymScope ss = null;
@@ -217,7 +212,7 @@ namespace VisualPascalABC
                                 for (int i = 0; i < ss.used_units.Count; i++)
                                 {
                                     string s = ss.used_units[i].file_name;
-                                    if (s != null && open_files2.ContainsKey(s) && recomp_files.ContainsKey(s))
+                                    if (s != null && open_files.ContainsKey(s) && recomp_files.ContainsKey(s))
                                     {
                                         is_comp = true;
                                         CodeCompletion.CodeCompletionController controller = new CodeCompletion.CodeCompletionController();

--- a/VisualPascalABCNETLinux/IB/CodeCompletion/CodeCompletionParserController.cs
+++ b/VisualPascalABCNETLinux/IB/CodeCompletion/CodeCompletionParserController.cs
@@ -172,6 +172,10 @@ namespace VisualPascalABC
                         if (string.IsNullOrEmpty(text))
                             text = "begin end.";
                         CodeCompletion.DomConverter tmp = CodeCompletion.CodeCompletionController.comp_modules[FileName] as CodeCompletion.DomConverter;
+
+                        // очистка кэша и данных от старых компиляций, чтобы при новой компиляции не появились ссылки на старые данные
+                        CodeCompletion.TypeTable.Clear();
+
                         long cur_mem = Environment.WorkingSet;
                         CodeCompletion.DomConverter dc = controller.Compile(FileName, text);
                         mem_delta += Environment.WorkingSet - cur_mem;
@@ -227,6 +231,10 @@ namespace VisualPascalABC
                                         CodeCompletion.CodeCompletionController controller = new CodeCompletion.CodeCompletionController();
                                         string text = visualEnvironmentCompiler.SourceFilesProvider(FileName, PascalABCCompiler.SourceFileOperation.GetText) as string;
                                         CodeCompletion.DomConverter tmp = CodeCompletion.CodeCompletionController.comp_modules[FileName] as CodeCompletion.DomConverter;
+
+                                        // очистка кэша и данных от старых компиляций, чтобы при новой компиляции не появились ссылки на старые данные
+                                        CodeCompletion.TypeTable.Clear();
+
                                         long cur_mem = Environment.WorkingSet;
                                         dc = controller.Compile(FileName, text);
                                         mem_delta += Environment.WorkingSet - cur_mem;
@@ -260,10 +268,7 @@ namespace VisualPascalABC
                     GC.Collect();
                 }
             }
-            catch (Exception e)
-            {
-
-            }
+            catch (Exception) { }
 
         }
 

--- a/VisualPascalABCNETLinux/IB/CodeCompletion/CodeCompletionParserController.cs
+++ b/VisualPascalABCNETLinux/IB/CodeCompletion/CodeCompletionParserController.cs
@@ -162,10 +162,6 @@ namespace VisualPascalABC
                         if (string.IsNullOrEmpty(text))
                             text = "begin end.";
                         CodeCompletion.DomConverter tmp = CodeCompletion.CodeCompletionController.comp_modules[FileName] as CodeCompletion.DomConverter;
-
-                        // очистка кэша и данных от старых компиляций, чтобы при новой компиляции не появились ссылки на старые данные
-                        CodeCompletion.TypeTable.Clear();
-
                         long cur_mem = Environment.WorkingSet;
                         CodeCompletion.DomConverter dc = controller.Compile(FileName, text);
                         mem_delta += Environment.WorkingSet - cur_mem;
@@ -221,10 +217,6 @@ namespace VisualPascalABC
                                         CodeCompletion.CodeCompletionController controller = new CodeCompletion.CodeCompletionController();
                                         string text = visualEnvironmentCompiler.SourceFilesProvider(FileName, PascalABCCompiler.SourceFileOperation.GetText) as string;
                                         CodeCompletion.DomConverter tmp = CodeCompletion.CodeCompletionController.comp_modules[FileName] as CodeCompletion.DomConverter;
-
-                                        // очистка кэша и данных от старых компиляций, чтобы при новой компиляции не появились ссылки на старые данные
-                                        CodeCompletion.TypeTable.Clear();
-
                                         long cur_mem = Environment.WorkingSet;
                                         dc = controller.Compile(FileName, text);
                                         mem_delta += Environment.WorkingSet - cur_mem;

--- a/VisualPascalABCNETLinux/IB/CodeCompletion/CodeCompletionParserController.cs
+++ b/VisualPascalABCNETLinux/IB/CodeCompletion/CodeCompletionParserController.cs
@@ -153,9 +153,8 @@ namespace VisualPascalABC
                 bool is_comp = false;
                 foreach (string FileName in open_files.Keys)
                 {
-                    //(ssyy) 18.05.08 Вставил проверку на null
-                    object o = open_files[FileName];
-                    if (o != null && (bool)o == true)
+                    
+                    if (open_files[FileName])
                     {
                         is_comp = true;
                         CodeCompletion.CodeCompletionController controller = new CodeCompletion.CodeCompletionController();

--- a/VisualPascalABCNETLinux/IB/CodeCompletion/CodeCompletionParserController.cs
+++ b/VisualPascalABCNETLinux/IB/CodeCompletion/CodeCompletionParserController.cs
@@ -3,12 +3,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Text;
-using System.Windows.Forms;
-using ICSharpCode.TextEditor;
-using ICSharpCode.TextEditor.Gui.CompletionWindow;
-using ICSharpCode.TextEditor.Document;
-using Languages.Integration;
 
 namespace VisualPascalABC
 {
@@ -16,7 +10,7 @@ namespace VisualPascalABC
 
     public class CodeCompletionParserController : VisualPascalABCPlugins.ICodeCompletionService
     {
-        public static Hashtable open_files = new Hashtable(StringComparer.OrdinalIgnoreCase);
+        public static Dictionary<string, bool> open_files = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         public VisualEnvironmentCompiler visualEnvironmentCompiler;
         private System.Threading.Thread th = null;
         private CodeCompletionProvider ccp;
@@ -91,8 +85,7 @@ namespace VisualPascalABC
         {
             if (CodeCompletion.CodeCompletionController.comp_modules[FileName] != null)
                 CodeCompletion.CodeCompletionController.comp_modules.Remove(FileName);
-            if (open_files[FileName] != null)
-                open_files.Remove(FileName);
+            open_files.Remove(FileName);
         }
 
         public void SetAsChanged(string FileName)
@@ -105,8 +98,7 @@ namespace VisualPascalABC
         {
             try
             {
-                Hashtable open_files2 = open_files.Clone() as Hashtable;
-                foreach (string s in open_files2.Keys)
+                foreach (string s in open_files.Keys)
                 {
                     if (ProjectFactory.Instance.CurrentProject.ContainsSourceFile(s))
                         open_files[s] = true;
@@ -157,10 +149,9 @@ namespace VisualPascalABC
         {
             try
             {
-                Hashtable open_files2 = (Hashtable)open_files.Clone();
-                Hashtable recomp_files = new Hashtable(StringComparer.OrdinalIgnoreCase);
+                Dictionary<string, string> recomp_files = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 bool is_comp = false;
-                foreach (string FileName in open_files2.Keys)
+                foreach (string FileName in open_files.Keys)
                 {
                     //(ssyy) 18.05.08 Вставил проверку на null
                     object o = open_files[FileName];
@@ -199,7 +190,7 @@ namespace VisualPascalABC
                             CodeCompletion.CodeCompletionController.comp_modules[FileName] = dc;
                     }
                 }
-                foreach (string FileName in open_files2.Keys)
+                foreach (string FileName in open_files.Keys)
                 {
                     CodeCompletion.DomConverter dc = CodeCompletion.CodeCompletionController.comp_modules[FileName] as CodeCompletion.DomConverter;
                     CodeCompletion.SymScope ss = null;
@@ -225,7 +216,7 @@ namespace VisualPascalABC
                                 for (int i = 0; i < ss.used_units.Count; i++)
                                 {
                                     string s = ss.used_units[i].file_name;
-                                    if (s != null && open_files2.ContainsKey(s) && recomp_files.ContainsKey(s))
+                                    if (s != null && open_files.ContainsKey(s) && recomp_files.ContainsKey(s))
                                     {
                                         is_comp = true;
                                         CodeCompletion.CodeCompletionController controller = new CodeCompletion.CodeCompletionController();


### PR DESCRIPTION
Добавлена очистка кэша типов и методов расширения у стандартных типов, чтобы избежать сохранения ссылок на неактуальные InterfaceUnitScope и ImplementationUnitScope во время перекомпиляции анализатором кода модуля PABCSystem. Тесты показывают, что теперь сборщик мусора очищает память после срабатывания Intellisense. Однако, все еще не решена проблема дубликатов экземпляров шаблонных типов, поэтому может быть временный рост по памяти вплоть до 500 Мб.