### PR TITLE
Удаление неиспользуемых строчек из `_GenerateAllSetups.bat`

### DIFF
--- a/_GenerateAllSetups.bat
+++ b/_GenerateAllSetups.bat
@@ -47,10 +47,6 @@ TestRunner.exe 6
 cd ..\ReleaseGenerators
 call PascalABCNET_ALL.bat
 
-cd ..
-
-dotnet build -c Release --no-incremental PascalABCNET.sln
-
 GOTO EXIT
 
 :ERROR


### PR DESCRIPTION
По словам @miks1965 строчки были связаны со сборкой для netfx 4.0. Тк сейчас под эту версию сборка не проводится, то строчки потеряли смысл