### PR TITLE
Upgrade windows runner for CI/CD

### DIFF
--- a/.github/workflows/buildandruntests.yml
+++ b/.github/workflows/buildandruntests.yml
@@ -21,7 +21,7 @@ jobs:
   build:
 
     name: Prepare and build on Windows Server 2016 VM
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
windows-2019 скоро отрубят:
https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/#windows-server-2019-is-closing-down
Полностью отрубят в конце июня, но начнут временно кидать ошибки уже в начале июня.

Мы сидели на windows-2019 потому что там была VS-2019.
Но теперь у нас .sln файлы основанные на SDK и зависимости от VS-2019 больше нету.

Это изменение только для сборки в облаке, локально вы можете всё ещё использовать VS-2019.