### PR TITLE
Больше уверенности, что IDE будет работать на Windows 8

### DIFF
--- a/VisualPascalABCNET/Config/AssemblyInfo.cs
+++ b/VisualPascalABCNET/Config/AssemblyInfo.cs
@@ -2,7 +2,12 @@
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
 
 [assembly: AssemblyTitle("PascalABC.NET")]
 [assembly: AssemblyDescription("PascalABC.NET Compiler GUI")]
 [assembly: AssemblyConfiguration("")]
+
+// IMPORTANT! IDE собирается под net462
+// Атрибут подменяется только для поддержки High DPI
+[assembly: TargetFramework(".NETFramework,Version=v4.7.1")]

--- a/VisualPascalABCNET/VisualPascalABCNET.csproj
+++ b/VisualPascalABCNET/VisualPascalABCNET.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net471</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <OutputType>WinExe</OutputType>
     
     <RootNamespace>VisualPascalABC</RootNamespace>
@@ -10,6 +10,7 @@
     
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     

--- a/VisualPascalABCNET/app.config
+++ b/VisualPascalABCNET/app.config
@@ -1,6 +1,11 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/></startup>
+  <startup>
+    <!-- IDE собирается под net462, но предполагается что будет работать и под net461 -->
+    <!-- net461 это последняя версия для win8 -->
+    <!-- для win7 и win8.1 доступны более новые версии net -->
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+  </startup>
 
   <System.Windows.Forms.ApplicationConfigurationSection>
     <add key="DpiAwareness" value="PerMonitorV2"/>


### PR DESCRIPTION
На данный момент IDE собирается под `net471`.  Это необходимо для корректной работы механизмов High DPI

В то время как последняя поддерживаемая версия net на `win8` это `4.6.1`. Таким образом, мы не можем получить от компилятора гарантию, что не используются типы и методы, которые появились после `4.6.1`

В этом PR я настраиваю проект так, что он компилируется для `4.6.2`, но помечается как откомпилированный для `4.7.1`. Таким образом
- High DPI работает как и раньше
- Компилятор даёт больше гарантий, что IDE запустится на более старых версиях net
___
Очевидный вопрос, я понизил версию `4.7.1 --> 4.6.2`. Хотя казалось бы нужно понизить до `4.6.1`. Дело в том, что в проекте уже есть зависимости, которые собраны под `4.6.2`, поэтому нет стопроцентной гарантии, что они заработают под `4.6.1`. То есть этот PR именно повышает надёжность, а не даёт гарантию

Возможно IDE уже сейчас не работает на `4.6.1` (У меня к сожалению нет возможности проверить). В таком случае мержить этот PR нет смысла. Помечу как черновик до получения подтверждения
___
Этот PR нужен только для работы с `win8`

Для `win7` и `win8.1` доступны все версии netfx вплоть до `4.8`

___
Гайд по изменённым файлам
`app.config` -- указал версия с которой ожидается, что IDE будет работать (`4.6.1`)
`VisualPascalABCNET.csproj` -- указал версию для которой фактически происходит компиляция (`4.6.2`)
`AssemblyInfo.cs` -- указал версию которой помечается бинарник (`4.7.1`)