### PR TITLE
Удаление недостижимого кода

### DIFF
--- a/NETGenerator/NETGenerator.cs
+++ b/NETGenerator/NETGenerator.cs
@@ -1935,7 +1935,7 @@ namespace PascalABCCompiler.NETGenerator
                     }
                     catch (Exception ex)
                     {
-                        if (icmn.method_info.DeclaringType.IsGenericType && !icmn.method_info.DeclaringType.IsGenericTypeDefinition)
+                        if ( icmn.method_info.DeclaringType.IsConstructedGenericType() )
                         {
                             Type gen_def_type = icmn.method_info.DeclaringType.GetGenericTypeDefinition();
 
@@ -1949,24 +1949,6 @@ namespace PascalABCCompiler.NETGenerator
                             }
 
                             mi = TypeBuilder.GetMethod(t, mi);
-                        }
-                        else if (t.Name != "TypeBuilderInstantiation")
-                        {
-                            try
-                            {
-                                foreach (MethodInfo mi2 in t.GetMethods())
-                                {
-                                    if (mi2.MetadataToken == icmn.method_info.MetadataToken)
-                                    {
-                                        mi = mi2;
-                                        break;
-                                    }
-                                }
-                            }
-                            catch
-                            {
-                                mi = icmn.method_info;
-                            }
                         }
                         else
                             mi = icmn.method_info;


### PR DESCRIPTION
Эта ветка никогда не выполнялась, тк в `t.Name` находится имя компилируемого типа. Например `IReadOnlyList<PascalType>`. 

`TypeBuilderInstantiation` это класс содержащий информацию о компилируемом типе (наследник `System.Type`)

То есть чтобы условие хоть когда-то выполнялось необходимо было написать `t.GetType().Name`

Но раз компилятор работал и без этой ветки, могу сделать вывод, что она осталась от экспериментов. Скорее всего эту ситуацию обслуживает ветка чуть выше