### PR TITLE
Исправление сравнения имён

### DIFF
--- a/NETGenerator/NETGenerator.cs
+++ b/NETGenerator/NETGenerator.cs
@@ -1950,7 +1950,7 @@ namespace PascalABCCompiler.NETGenerator
 
                             mi = TypeBuilder.GetMethod(t, mi);
                         }
-                        else if (t.Name != "TypeBuilderInstantiation")
+                        else if (t.GetType().Name != "TypeBuilderInstantiation")
                         {
                             try
                             {


### PR DESCRIPTION
В `t.Name` содержится имя компилируемого типа, например `IReadOnlyList<PascalType>`

Однако правым операндом сравнения выступает имя наследника `System.Type`, который используется для выражения компилируемого типа

Теперь сравнение происходит корректно. Однако я не нашёл ни одного случая, когда эта ветка вообще выполнялась