### PR TITLE
Update CodeCompletionActions.cs

### DIFF
--- a/VisualPascalABCNETLinux/IB/CodeCompletion/CodeCompletionActions.cs
+++ b/VisualPascalABCNETLinux/IB/CodeCompletion/CodeCompletionActions.cs
@@ -691,7 +691,7 @@ namespace VisualPascalABC
                 completionDataProvider.preSelection = CodeCompletion.CodeCompletionController.CurrentParser.LanguageInformation.FindPattern(off, text, out is_pattern);
 
                 if (!is_pattern && off > 0 && text[off - 1] == '.')
-                    key = '$';
+                    key = '_';//was '$'
                 codeCompletionWindow = PABCNETCodeCompletionWindow.ShowCompletionWindow(
                     VisualPABCSingleton.MainForm,					// The parent window for the completion window
                     textArea.MotherTextEditorControl, 					// The text editor to show the window for


### PR DESCRIPTION
[LIN][IDE]Показ Code Completion Window по Ctrl-Space, если курсор находится сразу после точки (как сделано в Win версии). Текущее поведение - после точки ccw не показывать, только если курсор переместить на несколько символов вправо от точки.

На скриншоте исправленное поведение
<img width="596" height="492" alt="изображение" src="https://github.com/user-attachments/assets/33f1bdbf-d096-4ec2-b6f7-7c44ff6e891e" />
