### PR TITLE
Рефакторинг в Intellisense

### DIFF
--- a/CodeCompletion/CodeCompletion.cs
+++ b/CodeCompletion/CodeCompletion.cs
@@ -9,15 +9,13 @@ using PascalABCCompiler.Parsers;
 using PascalABCCompiler.Errors;
 using System.IO;
 using Languages.Facade;
-//using ICSharpCode.SharpDevelop.Dom;
 
 namespace CodeCompletion
 {
     public class CodeCompletionController
     {
-        public static LanguageProvider LanguageProvider = LanguageProvider.Instance;
-        private string FileName;
-        string Text;
+        private static readonly LanguageProvider LanguageProvider = LanguageProvider.Instance;
+
         public Dictionary<syntax_tree_node, string> docs = new Dictionary<syntax_tree_node, string>();
 		// static bool parsers_loaded=false;
 		public IParser Parser;
@@ -70,8 +68,6 @@ namespace CodeCompletion
         
         public DomConverter Compile(string FileName, string Text)
         {
-            this.Text = Text;
-            this.FileName = FileName;
             List<Error> ErrorsList = new List<Error>();
             List<CompilerWarning> Warnings = new List<CompilerWarning>();
             compilation_unit cu = null;
@@ -170,8 +166,7 @@ namespace CodeCompletion
 
         public DomConverter CompileAllIfNeed(string FileName, bool parse_only_interface=false)
         {
-            this.FileName = FileName;
-            this.Text = comp.GetSourceFileText(FileName);
+            string Text = comp.GetSourceFileText(FileName);
             List<Error> ErrorsList = new List<Error>();
             List<CompilerWarning> Warnings = new List<CompilerWarning>();
             compilation_unit cu = null;

--- a/CodeCompletion/CodeCompletion.cs
+++ b/CodeCompletion/CodeCompletion.cs
@@ -39,7 +39,7 @@ namespace CodeCompletion
         }
 
         public static PascalABCCompiler.Compiler comp;// = new PascalABCCompiler.Compiler();
-        public static Hashtable StandartDirectories = new Hashtable();
+        public static Dictionary<string, string> StandartDirectories = new Dictionary<string, string>();
         public static Hashtable comp_modules = new Hashtable(StringComparer.OrdinalIgnoreCase);
         // public static Hashtable parsers = new Hashtable(StringComparer.OrdinalIgnoreCase);
         public static Dictionary<string, InterfaceUnitScope> pabcNamespaces = new Dictionary<string, InterfaceUnitScope>();
@@ -409,8 +409,8 @@ namespace CodeCompletion
             if (CodeCompletionController.comp != null)
                 Dirs.AddRange(CodeCompletionController.comp.CompilerOptions.SearchDirectories);
             // Надо как-то проверять, что мы не в инсталированной версии EVA
-            if (CodeCompletionController.StandartDirectories.ContainsKey(LibSourceDirectoryIdent) && Directory.Exists((string)CodeCompletionController.StandartDirectories[LibSourceDirectoryIdent]))
-                Dirs.Add((string)CodeCompletionController.StandartDirectories[LibSourceDirectoryIdent]);
+            if (CodeCompletionController.StandartDirectories.ContainsKey(LibSourceDirectoryIdent) && Directory.Exists(CodeCompletionController.StandartDirectories[LibSourceDirectoryIdent]))
+                Dirs.Add(CodeCompletionController.StandartDirectories[LibSourceDirectoryIdent]);
             return CodeCompletionController.comp.FindSourceFileNameInDirs(unit_name, out found_dir_ind, caseSensitiveSearch, Dirs.ToArray());
         }
 

--- a/CodeCompletion/DomSyntaxTreeVisitor.cs
+++ b/CodeCompletion/DomSyntaxTreeVisitor.cs
@@ -15,10 +15,6 @@ using System.Text;
 
 namespace CodeCompletion
 {
-    public class SemanticOptions
-	{
-		public bool allow_import_types=true;
-	}
 	
 	public class DomSyntaxTreeVisitor : AbstractVisitor
     {
@@ -44,7 +40,6 @@ namespace CodeCompletion
         private static Compiler compiler;
         public static bool use_semantic_for_intellisense;
         private Dictionary<method_call, SymScope> method_call_cache = new Dictionary<method_call, SymScope>();
-        public SemanticOptions semantic_options = new SemanticOptions();
         public Hashtable cur_used_assemblies;
 
         public DomSyntaxTreeVisitor(DomConverter converter)
@@ -2701,8 +2696,7 @@ namespace CodeCompletion
                 {
                     unit_or_namespace s = _interface_node.uses_modules.units[j];
                     CompileUsedUnitOrNamespace(s, Path.GetDirectoryName(_unit_module.file_name),
-                        cur_scope, ns_cache, semantic_options.allow_import_types,
-                        unl, currentUnitLanguage.CaseSensitive);
+                        cur_scope, ns_cache, unl, currentUnitLanguage.CaseSensitive);
                 }
             }
 
@@ -2899,8 +2893,7 @@ namespace CodeCompletion
         }
 
         private void CompileUsedUnitOrNamespace(unit_or_namespace s, string curr_path,
-            SymScope cur_scope, Hashtable ns_cache, bool allow_import_types,
-            using_namespace_list unl, bool caseSensitiveSearch)
+            SymScope cur_scope, Hashtable ns_cache, using_namespace_list unl, bool caseSensitiveSearch)
         {
 
             try
@@ -2961,6 +2954,7 @@ namespace CodeCompletion
                                     cur_scope.AddName(usedName, ns_scope);
                                     cur_scope.AddUsedUnit(ns_scope);
                                 }
+                                // Не поддерживается в основном компиляторе EVA
                                 /*else if (PascalABCCompiler.NetHelper.NetHelper.IsType(usedName) && allow_import_types)
                                 {
                                     Type t = PascalABCCompiler.NetHelper.NetHelper.FindType(usedName);
@@ -3024,8 +3018,7 @@ namespace CodeCompletion
         }
 
         private void CompileImportedUnit(string importedName, statement importStatement, as_statement_list asStatementsList, string curr_path,
-            SymScope cur_scope, Hashtable ns_cache, bool allow_import_types,
-            using_namespace_list unl, bool caseSensitiveSearch)
+            SymScope cur_scope, using_namespace_list unl, bool caseSensitiveSearch)
         {
             try
             {
@@ -3263,8 +3256,7 @@ namespace CodeCompletion
                 {
                     unit_or_namespace s = _program_module.used_units.units[j];
                     CompileUsedUnitOrNamespace(s, Path.GetDirectoryName(_program_module.file_name),
-                        cur_scope, ns_cache, semantic_options.allow_import_types,
-                        unl, currentUnitLanguage.CaseSensitive);
+                        cur_scope, ns_cache, unl, currentUnitLanguage.CaseSensitive);
                 }
             }
 
@@ -3353,8 +3345,7 @@ namespace CodeCompletion
                     {
                         CompileImportedUnit(unitNode.name, import, import.modules_names,
                             Path.GetDirectoryName(fileName),
-                            cur_scope, ns_cache, semantic_options.allow_import_types,
-                            unl, caseSensitiveSearch);
+                            cur_scope, unl, caseSensitiveSearch);
 
                         usedUnitNames.Add(unitNode.name);
                     }
@@ -3363,8 +3354,7 @@ namespace CodeCompletion
                 {
                     CompileImportedUnit(fromImport.module_name.name, fromImport, fromImport.imported_names,
                         Path.GetDirectoryName(fileName),
-                        cur_scope, ns_cache, semantic_options.allow_import_types,
-                        unl, caseSensitiveSearch);
+                        cur_scope, unl, caseSensitiveSearch);
 
                     usedUnitNames.Add(fromImport.module_name.name);
                 }
@@ -5056,8 +5046,7 @@ namespace CodeCompletion
                 {
                     unit_or_namespace s = _implementation_node.uses_modules.units[j];
                     CompileUsedUnitOrNamespace(s, Path.GetDirectoryName(this.cur_unit_file_name),
-                        cur_scope, ns_cache, semantic_options.allow_import_types, 
-                        unl, currentLanguage.CaseSensitive);
+                        cur_scope, ns_cache, unl, currentLanguage.CaseSensitive);
                 }
             }
             impl_scope = cur_scope;

--- a/CodeCompletion/DomSyntaxTreeVisitor.cs
+++ b/CodeCompletion/DomSyntaxTreeVisitor.cs
@@ -2961,12 +2961,11 @@ namespace CodeCompletion
                                     cur_scope.AddName(usedName, ns_scope);
                                     cur_scope.AddUsedUnit(ns_scope);
                                 }
-                                else if (PascalABCCompiler.NetHelper.NetHelper.IsType(usedName) && allow_import_types)
+                                /*else if (PascalABCCompiler.NetHelper.NetHelper.IsType(usedName) && allow_import_types)
                                 {
                                     Type t = PascalABCCompiler.NetHelper.NetHelper.FindType(usedName);
                                     cur_scope.AddUsedUnit(new NamespaceTypeScope(TypeTable.get_compiled_type(new SymInfo(t.Name, SymbolKind.Class, t.FullName), t)));
-                                }
-
+                                }*/
                             }
                         }
                     }

--- a/CodeCompletion/SymTable.cs
+++ b/CodeCompletion/SymTable.cs
@@ -5387,7 +5387,7 @@ namespace CodeCompletion
     //		
     //	}
 
-    public class NamespaceTypeScope : SymScope, INamespaceTypeScope
+    /*public class NamespaceTypeScope : SymScope, INamespaceTypeScope
     {
         private CompiledScope entry_type;
 
@@ -5433,7 +5433,7 @@ namespace CodeCompletion
         {
             return entry_type.GetStaticNames();
         }
-    }
+    }*/
 
     public class NamespaceScope : SymScope, INamespaceScope
     {

--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -448,13 +448,13 @@ namespace PascalABCCompiler
         }
         //для поиска pcu в третью очередь исп. путь к pas файлу
 
-        public Hashtable StandardDirectories;
+        public Dictionary<string, string> StandardDirectories;
 
         private void SetDirectories()
         {
             SystemDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().ManifestModule.FullyQualifiedName);
 
-            StandardDirectories = new Hashtable(StringComparer.InvariantCultureIgnoreCase)
+            StandardDirectories = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
             {
                 { "%PABCSYSTEM%", SystemDirectory }
             };

--- a/CompilerTools/Tools.cs
+++ b/CompilerTools/Tools.cs
@@ -20,11 +20,11 @@ namespace PascalABCCompiler
                     sc.begin_position.line_num, sc.begin_position.column_num,
                     sc.end_position.line_num, sc.end_position.column_num);
         }
-        public static string ReplaceAllKeys(string str, Hashtable hashtable)
+        public static string ReplaceAllKeys(string str, Dictionary<string, string> hashtable)
         {
             foreach (string key in hashtable.Keys)
                 if (hashtable[key] != null)
-                    str = str.Replace(key, hashtable[key].ToString());
+                    str = str.Replace(key, hashtable[key]);
             return str;
         }
 

--- a/NETGenerator/CodeGenerator.cs
+++ b/NETGenerator/CodeGenerator.cs
@@ -7,8 +7,7 @@
  *
  ***************************************************************************/
 
-using System;
-using System.Collections;
+using System.Collections.Generic;
 using PascalABCCompiler.NetHelper;
 
 namespace PascalABCCompiler.CodeGenerators
@@ -23,7 +22,7 @@ namespace PascalABCCompiler.CodeGenerators
 		private NETGenerator.ILConverter il_converter;//=new NETGenerator.ILConverter();
 
 		public void GenerateILCodeAndSaveAssembly(SemanticTree.IProgramNode ProgramTree,string TargetFileName,string SourceFileName ,
-            NETGenerator.CompilerOptions options, Hashtable StandartDirectories, string[] ResourceFiles)
+            NETGenerator.CompilerOptions options, Dictionary<string, string> StandartDirectories, string[] ResourceFiles)
 		{
             il_converter = new NETGenerator.ILConverter(StandartDirectories);
 			il_converter.ConvertFromTree(ProgramTree, TargetFileName, SourceFileName, options, ResourceFiles);

--- a/NETGenerator/NETGenerator.cs
+++ b/NETGenerator/NETGenerator.cs
@@ -271,9 +271,9 @@ namespace PascalABCCompiler.NETGenerator
             make_next_spoint = true;
         }
 
-        private Hashtable StandartDirectories;
+        private Dictionary<string, string> StandartDirectories;
 
-        public ILConverter(Hashtable StandartDirectories)
+        public ILConverter(Dictionary<string, string> StandartDirectories)
         {
             this.StandartDirectories = StandartDirectories;
         }

--- a/VisualPascalABCNET/DS/VisualEnvironmentCompiler.cs
+++ b/VisualPascalABCNET/DS/VisualEnvironmentCompiler.cs
@@ -62,7 +62,7 @@ namespace VisualPascalABC
         private DebugHelper DebugHelper;
 		private CodeCompletionParserController CodeCompletionParserController;
 		public UserOptions UserOptions;
-        private System.Collections.Hashtable StandartDirectories;
+        private Dictionary<string, string> StandartDirectories;
         Dictionary<string, CodeFileDocumentControl> OpenDocuments;
 
         public VisualEnvironmentCompiler(InvokeDegegate beginInvoke, 
@@ -70,7 +70,7 @@ namespace VisualPascalABC
             SetTextDelegate addTextToCompilerMessages, ToolStripMenuItem pluginsMenuItem, 
             ToolStrip pluginsToolStrip, ExecuteSourceLocationActionDelegate ExecuteSLAction, 
             ExecuteVisualEnvironmentCompilerActionDelegate ExecuteVECAction,
-            PascalABCCompiler.Errors.ErrorsStrategyManager ErrorsManager, RunManager RunnerManager, DebugHelper DebugHelper,UserOptions UserOptions,System.Collections.Hashtable StandartDirectories,
+            PascalABCCompiler.Errors.ErrorsStrategyManager ErrorsManager, RunManager RunnerManager, DebugHelper DebugHelper,UserOptions UserOptions, Dictionary<string, string> StandartDirectories,
             Dictionary<string, CodeFileDocumentControl> OpenDocuments, IWorkbench workbench)
         {
             this.StandartDirectories = StandartDirectories;

--- a/VisualPascalABCNET/DockContent/CodeFileDocumentTextEditorControl.cs
+++ b/VisualPascalABCNET/DockContent/CodeFileDocumentTextEditorControl.cs
@@ -117,7 +117,8 @@ namespace VisualPascalABC
 		
 		public void UpdateFolding()
 		{
-			CodeCompletionParserController.open_files[this.FileName] = true;
+            if (Languages.Facade.LanguageProvider.Instance.HasLanguageForExtension(FileName))
+			    CodeCompletionParserController.filesToParse[FileName] = true;
 		}
 		
         public void CollapseRegions()

--- a/VisualPascalABCNET/Form1.cs
+++ b/VisualPascalABCNET/Form1.cs
@@ -297,7 +297,7 @@ namespace VisualPascalABC
 
             PlayPauseButtonsVisibleInPanel = false;
 
-            WorkbenchStorage.StandartDirectories = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
+            WorkbenchStorage.StandartDirectories = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
             WorkbenchStorage.StandartDirectories.Add(Constants.SystemDirectoryIdent, System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().ManifestModule.FullyQualifiedName));
 
             RestoreDesktop();
@@ -614,10 +614,11 @@ namespace VisualPascalABC
                 case VisualEnvironmentCompilerAction.OpenFile:
                     return WorkbenchServiceFactory.FileService.OpenFile((string)obj, null);
                 case VisualEnvironmentCompilerAction.GetDirectory:
-                    string s=VisualEnvironmentCompiler.Compiler.CompilerOptions.StandardDirectories[(string)obj] as string;
-                    if (s != null) 
+                    VisualEnvironmentCompiler.Compiler.CompilerOptions.StandardDirectories.TryGetValue((string)obj, out var s);
+                    if (s != null)
                         return s;
-                    return WorkbenchStorage.StandartDirectories[(string)obj] as string;
+                    WorkbenchStorage.StandartDirectories.TryGetValue((string)obj, out s);
+                    return s;
                 case VisualEnvironmentCompilerAction.PT4PositionCursorAfterTask: // SSM 09.11.19
                     {
                         var ta = CurrentCodeFileDocument.TextEditor.ActiveTextAreaControl.TextArea;

--- a/VisualPascalABCNET/IB/CodeCompletion/CodeCompletionParserController.cs
+++ b/VisualPascalABCNET/IB/CodeCompletion/CodeCompletionParserController.cs
@@ -10,7 +10,7 @@ namespace VisualPascalABC
 
     public class CodeCompletionParserController : VisualPascalABCPlugins.ICodeCompletionService
     {
-        public static Dictionary<string, bool> open_files = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+        public static Dictionary<string, bool> filesToParse = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         public VisualEnvironmentCompiler visualEnvironmentCompiler;
         private System.Threading.Thread th = null;
         private CodeCompletionProvider ccp;
@@ -67,40 +67,42 @@ namespace VisualPascalABC
                 CodeCompletion.CodeCompletionController.comp_modules[NewFileName] = CodeCompletion.CodeCompletionController.comp_modules[OldFileName];
                 if (CodeCompletion.CodeCompletionController.comp_modules.ContainsKey(OldFileName))
                     CodeCompletion.CodeCompletionController.comp_modules.Remove(OldFileName);
-                open_files[NewFileName] = open_files[OldFileName];
-                if (open_files.ContainsKey(OldFileName))
-                    open_files.Remove(OldFileName);
+                filesToParse[NewFileName] = filesToParse[OldFileName];
+                if (filesToParse.ContainsKey(OldFileName))
+                    filesToParse.Remove(OldFileName);
             }
         }
 
         public void RegisterFileForParsing(string FileName)
         {
-            open_files[FileName] = true;
-            CodeCompletion.CodeCompletionController.SetLanguage(FileName);
-            //ParseAllFiles();
+            if (Languages.Facade.LanguageProvider.Instance.HasLanguageForExtension(FileName))
+            {
+                filesToParse[FileName] = true;
+                CodeCompletion.CodeCompletionController.SetLanguage(FileName);
+            }
         }
 
         public void CloseFile(string FileName)
         {
             if (CodeCompletion.CodeCompletionController.comp_modules[FileName] != null)
                 CodeCompletion.CodeCompletionController.comp_modules.Remove(FileName);
-            open_files.Remove(FileName);
+            filesToParse.Remove(FileName);
         }
 
         public void SetAsChanged(string FileName)
         {
-            if (FileName != null)
-                open_files[FileName] = true;
+            if (FileName != null && filesToParse.ContainsKey(FileName))
+                filesToParse[FileName] = true;
         }
 
         public void SetAllInProjectChanged()
         {
             try
             {
-                foreach (string s in open_files.Keys.ToArray())
+                foreach (string s in filesToParse.Keys.ToArray())
                 {
                     if (ProjectFactory.Instance.CurrentProject.ContainsSourceFile(s))
-                        open_files[s] = true;
+                        filesToParse[s] = true;
                 }
             }
             catch (Exception) { }
@@ -146,10 +148,10 @@ namespace VisualPascalABC
             {
                 Dictionary<string, string> recomp_files = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 bool is_comp = false;
-                foreach (string FileName in open_files.Keys.ToArray()) // копирование ключей обязательно, иначе будет InvalidOperationException EVA
+                foreach (string FileName in filesToParse.Keys.ToArray()) // копирование ключей обязательно, иначе будет InvalidOperationException EVA
                 {
 
-                    if (open_files[FileName])
+                    if (filesToParse[FileName])
                     {
                         is_comp = true;
                         CodeCompletion.CodeCompletionController controller = new CodeCompletion.CodeCompletionController();
@@ -160,7 +162,7 @@ namespace VisualPascalABC
                         long cur_mem = Environment.WorkingSet;
                         CodeCompletion.DomConverter dc = controller.Compile(FileName, text);
                         mem_delta += Environment.WorkingSet - cur_mem;
-                        open_files[FileName] = false;
+                        filesToParse[FileName] = false;
                         if (dc.is_compiled)
                         {
                             //CodeCompletion.CodeCompletionController.comp_modules.Remove(file_name);
@@ -172,7 +174,7 @@ namespace VisualPascalABC
                             }
                             CodeCompletion.CodeCompletionController.comp_modules[FileName] = dc;
                             recomp_files[FileName] = FileName;
-                            open_files[FileName] = false;
+                            filesToParse[FileName] = false;
                             if (ParseInformationUpdated != null)
                                 ParseInformationUpdated(dc.visitor.entry_scope, FileName);
                         }
@@ -180,7 +182,7 @@ namespace VisualPascalABC
                             CodeCompletion.CodeCompletionController.comp_modules[FileName] = dc;
                     }
                 }
-                foreach (string FileName in open_files.Keys.ToArray()) // копирование ключей обязательно, иначе будет InvalidOperationException EVA
+                foreach (string FileName in filesToParse.Keys.ToArray()) // копирование ключей обязательно, иначе будет InvalidOperationException EVA
                 {
                     CodeCompletion.DomConverter dc = CodeCompletion.CodeCompletionController.comp_modules[FileName] as CodeCompletion.DomConverter;
                     CodeCompletion.SymScope ss = null;
@@ -206,7 +208,7 @@ namespace VisualPascalABC
                                 for (int i = 0; i < ss.used_units.Count; i++)
                                 {
                                     string s = ss.used_units[i].file_name;
-                                    if (s != null && open_files.ContainsKey(s) && recomp_files.ContainsKey(s))
+                                    if (s != null && filesToParse.ContainsKey(s) && recomp_files.ContainsKey(s))
                                     {
                                         is_comp = true;
                                         CodeCompletion.CodeCompletionController controller = new CodeCompletion.CodeCompletionController();
@@ -215,7 +217,7 @@ namespace VisualPascalABC
                                         long cur_mem = Environment.WorkingSet;
                                         dc = controller.Compile(FileName, text);
                                         mem_delta += Environment.WorkingSet - cur_mem;
-                                        open_files[FileName] = false;
+                                        filesToParse[FileName] = false;
                                         CodeCompletion.CodeCompletionController.comp_modules[FileName] = dc;
                                         if (dc.is_compiled)
                                         {

--- a/VisualPascalABCNET/IB/CodeCompletion/CodeCompletionProvider.cs
+++ b/VisualPascalABCNET/IB/CodeCompletion/CodeCompletionProvider.cs
@@ -257,7 +257,7 @@ namespace VisualPascalABC
                 }
                 if (fnd_scope != null)
                 {
-                    foreach (string FileName in CodeCompletionParserController.open_files.Keys)
+                    foreach (string FileName in CodeCompletionParserController.filesToParse.Keys)
                     {
                         CodeCompletion.CodeCompletionController controller = new CodeCompletion.CodeCompletionController();
                         string text = VisualPABCSingleton.MainForm.VisualEnvironmentCompiler.SourceFilesProvider(FileName, PascalABCCompiler.SourceFileOperation.GetText) as string;

--- a/VisualPascalABCNET/Workbench/BuildService.cs
+++ b/VisualPascalABCNET/Workbench/BuildService.cs
@@ -68,7 +68,7 @@ namespace VisualPascalABC
             CompilerOptions1.UseDllForSystemUnits = false;
             CompilerOptions1.RunWithEnvironment = RunWithEnvironment;
             bool savePCU = Workbench.VisualEnvironmentCompiler.Compiler.InternalDebug.PCUGenerate;
-            if (Path.GetDirectoryName(CompilerOptions1.SourceFileName).ToLower() == ((string)WorkbenchStorage.StandartDirectories[Constants.LibSourceDirectoryIdent]).ToLower())
+            if (Path.GetDirectoryName(CompilerOptions1.SourceFileName).ToLower() == WorkbenchStorage.StandartDirectories[Constants.LibSourceDirectoryIdent].ToLower())
                 Workbench.VisualEnvironmentCompiler.Compiler.InternalDebug.PCUGenerate = false;
 
             if (RuntimeServicesModule != null)
@@ -128,7 +128,7 @@ namespace VisualPascalABC
 
             //CompilerOptions1.SavePCUInThreadPull = true;
             bool savePCU = Workbench.VisualEnvironmentCompiler.Compiler.InternalDebug.PCUGenerate;
-            if (Path.GetDirectoryName(FileName).ToLower() == ((string)WorkbenchStorage.StandartDirectories[Constants.LibSourceDirectoryIdent]).ToLower())
+            if (Path.GetDirectoryName(FileName).ToLower() == WorkbenchStorage.StandartDirectories[Constants.LibSourceDirectoryIdent].ToLower())
                 Workbench.VisualEnvironmentCompiler.Compiler.InternalDebug.PCUGenerate = false;
 
             string ofn = Workbench.VisualEnvironmentCompiler.Compile(CompilerOptions1);
@@ -220,7 +220,7 @@ namespace VisualPascalABC
 
             //CompilerOptions1.SavePCUInThreadPull = true;
             __savePCU = Workbench.VisualEnvironmentCompiler.Compiler.InternalDebug.PCUGenerate;
-            if (Path.GetDirectoryName(FileName).ToLower() == ((string)WorkbenchStorage.StandartDirectories[Constants.LibSourceDirectoryIdent]).ToLower())
+            if (Path.GetDirectoryName(FileName).ToLower() == WorkbenchStorage.StandartDirectories[Constants.LibSourceDirectoryIdent].ToLower())
                 Workbench.VisualEnvironmentCompiler.Compiler.InternalDebug.PCUGenerate = false;
 
             Workbench.VisualEnvironmentCompiler.Compiler.OnChangeCompilerState += CompilationOnChangeCompilerState;

--- a/VisualPascalABCNET/Workbench/WorkbenchServiceFactory.cs
+++ b/VisualPascalABCNET/Workbench/WorkbenchServiceFactory.cs
@@ -231,7 +231,7 @@ namespace VisualPascalABC
         internal static string WorkingDirectory = null;
         internal static string WorkingDirectoryInOptionsFile = null;
         internal static string LibSourceDirectory = null;
-        internal static Hashtable StandartDirectories;
+        internal static Dictionary<string, string> StandartDirectories;
         internal static System.Threading.Thread MainProgramThread;
         internal static bool SetCurrentTabPageIfWriteToOutputWindow = false;
         internal static bool WorkingDirectoryExsist

--- a/VisualPascalABCNETLinux/DS/VisualEnvironmentCompiler.cs
+++ b/VisualPascalABCNETLinux/DS/VisualEnvironmentCompiler.cs
@@ -60,7 +60,7 @@ namespace VisualPascalABC
         private DebugHelper DebugHelper;
 		private CodeCompletionParserController CodeCompletionParserController;
 		public UserOptions UserOptions;
-        private System.Collections.Hashtable StandartDirectories;
+        private Dictionary<string, string> StandartDirectories;
         Dictionary<string, CodeFileDocumentControl> OpenDocuments;
 
         public VisualEnvironmentCompiler(InvokeDegegate beginInvoke, 
@@ -68,7 +68,7 @@ namespace VisualPascalABC
             SetTextDelegate addTextToCompilerMessages, ToolStripMenuItem pluginsMenuItem, 
             ToolStrip pluginsToolStrip, ExecuteSourceLocationActionDelegate ExecuteSLAction, 
             ExecuteVisualEnvironmentCompilerActionDelegate ExecuteVECAction,
-            PascalABCCompiler.Errors.ErrorsStrategyManager ErrorsManager, RunManager RunnerManager, DebugHelper DebugHelper,UserOptions UserOptions,System.Collections.Hashtable StandartDirectories,
+            PascalABCCompiler.Errors.ErrorsStrategyManager ErrorsManager, RunManager RunnerManager, DebugHelper DebugHelper,UserOptions UserOptions, Dictionary<string, string> StandartDirectories,
             Dictionary<string, CodeFileDocumentControl> OpenDocuments, IWorkbench workbench)
         {
             this.StandartDirectories = StandartDirectories;

--- a/VisualPascalABCNETLinux/DockContent/CodeFileDocumentTextEditorControl.cs
+++ b/VisualPascalABCNETLinux/DockContent/CodeFileDocumentTextEditorControl.cs
@@ -114,12 +114,13 @@ namespace VisualPascalABC
 		{
 			ActiveTextAreaControl.TextArea.Refresh(ActiveTextAreaControl.TextArea.FoldMargin);
 		}
-		
-		public void UpdateFolding()
-		{
-			CodeCompletionParserController.open_files[this.FileName] = true;
-		}
-		
+
+        public void UpdateFolding()
+        {
+            if (Languages.Facade.LanguageProvider.Instance.HasLanguageForExtension(FileName))
+                CodeCompletionParserController.filesToParse[FileName] = true;
+        }
+
         public void CollapseRegions()
         {
             foreach (FoldMarker marker in Document.FoldingManager.FoldMarker)

--- a/VisualPascalABCNETLinux/Form1.cs
+++ b/VisualPascalABCNETLinux/Form1.cs
@@ -357,7 +357,7 @@ namespace VisualPascalABC
 
             PlayPauseButtonsVisibleInPanel = false;
 
-            WorkbenchStorage.StandartDirectories = new Hashtable(StringComparer.InvariantCultureIgnoreCase);
+            WorkbenchStorage.StandartDirectories = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
             WorkbenchStorage.StandartDirectories.Add(Constants.SystemDirectoryIdent, System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().ManifestModule.FullyQualifiedName));
 
             //---------------------------------------------
@@ -707,10 +707,11 @@ namespace VisualPascalABC
                 case VisualEnvironmentCompilerAction.OpenFile:
                     return WorkbenchServiceFactory.FileService.OpenFile((string)obj, null);
                 case VisualEnvironmentCompilerAction.GetDirectory:
-                    string s=VisualEnvironmentCompiler.Compiler.CompilerOptions.StandardDirectories[(string)obj] as string;
-                    if (s != null) 
+                    VisualEnvironmentCompiler.Compiler.CompilerOptions.StandardDirectories.TryGetValue((string)obj, out var s);
+                    if (s != null)
                         return s;
-                    return WorkbenchStorage.StandartDirectories[(string)obj] as string;
+                    WorkbenchStorage.StandartDirectories.TryGetValue((string)obj, out s);
+                    return s;
                 case VisualEnvironmentCompilerAction.PT4PositionCursorAfterTask: // SSM 09.11.19
                     {
                         var ta = CurrentCodeFileDocument.TextEditor.ActiveTextAreaControl.TextArea;

--- a/VisualPascalABCNETLinux/IB/CodeCompletion/CodeCompletionProvider.cs
+++ b/VisualPascalABCNETLinux/IB/CodeCompletion/CodeCompletionProvider.cs
@@ -257,7 +257,7 @@ namespace VisualPascalABC
                 }
                 if (fnd_scope != null)
                 {
-                    foreach (string FileName in CodeCompletionParserController.open_files.Keys)
+                    foreach (string FileName in CodeCompletionParserController.filesToParse.Keys)
                     {
                         CodeCompletion.CodeCompletionController controller = new CodeCompletion.CodeCompletionController();
                         string text = VisualPABCSingleton.MainForm.VisualEnvironmentCompiler.SourceFilesProvider(FileName, PascalABCCompiler.SourceFileOperation.GetText) as string;

--- a/VisualPascalABCNETLinux/Workbench/BuildService.cs
+++ b/VisualPascalABCNETLinux/Workbench/BuildService.cs
@@ -66,7 +66,7 @@ namespace VisualPascalABC
             CompilerOptions1.UseDllForSystemUnits = false;
             CompilerOptions1.RunWithEnvironment = RunWithEnvironment;
             bool savePCU = Workbench.VisualEnvironmentCompiler.Compiler.InternalDebug.PCUGenerate;
-            if (Path.GetDirectoryName(CompilerOptions1.SourceFileName).ToLower() == ((string)WorkbenchStorage.StandartDirectories[Constants.LibSourceDirectoryIdent]).ToLower())
+            if (Path.GetDirectoryName(CompilerOptions1.SourceFileName).ToLower() == WorkbenchStorage.StandartDirectories[Constants.LibSourceDirectoryIdent].ToLower())
                 Workbench.VisualEnvironmentCompiler.Compiler.InternalDebug.PCUGenerate = false;
 
             if (RuntimeServicesModule != null)
@@ -127,7 +127,7 @@ namespace VisualPascalABC
 
             //CompilerOptions1.SavePCUInThreadPull = true;
             bool savePCU = Workbench.VisualEnvironmentCompiler.Compiler.InternalDebug.PCUGenerate;
-            if (Path.GetDirectoryName(FileName).ToLower() == ((string)WorkbenchStorage.StandartDirectories[Constants.LibSourceDirectoryIdent]).ToLower())
+            if (Path.GetDirectoryName(FileName).ToLower() == WorkbenchStorage.StandartDirectories[Constants.LibSourceDirectoryIdent].ToLower())
                 Workbench.VisualEnvironmentCompiler.Compiler.InternalDebug.PCUGenerate = false;
 
             //MessageBox.Show("111");
@@ -223,7 +223,7 @@ namespace VisualPascalABC
 
             //CompilerOptions1.SavePCUInThreadPull = true;
             __savePCU = Workbench.VisualEnvironmentCompiler.Compiler.InternalDebug.PCUGenerate;
-            if (Path.GetDirectoryName(FileName).ToLower() == ((string)WorkbenchStorage.StandartDirectories[Constants.LibSourceDirectoryIdent]).ToLower())
+            if (Path.GetDirectoryName(FileName).ToLower() == WorkbenchStorage.StandartDirectories[Constants.LibSourceDirectoryIdent].ToLower())
                 Workbench.VisualEnvironmentCompiler.Compiler.InternalDebug.PCUGenerate = false;
 
             Workbench.VisualEnvironmentCompiler.Compiler.OnChangeCompilerState += CompilationOnChangeCompilerState;

--- a/VisualPascalABCNETLinux/Workbench/WorkbenchServiceFactory.cs
+++ b/VisualPascalABCNETLinux/Workbench/WorkbenchServiceFactory.cs
@@ -231,7 +231,7 @@ namespace VisualPascalABC
         internal static string WorkingDirectory = null;
         internal static string WorkingDirectoryInOptionsFile = null;
         internal static string LibSourceDirectory = null;
-        internal static Hashtable StandartDirectories;
+        internal static Dictionary<string, string> StandartDirectories;
         internal static System.Threading.Thread MainProgramThread;
         internal static bool SetCurrentTabPageIfWriteToOutputWindow = false;
         internal static bool WorkingDirectoryExsist

--- a/bin/Lib/SPythonSystem.pas
+++ b/bin/Lib/SPythonSystem.pas
@@ -1,10 +1,11 @@
 ﻿{$HiddenIdents}
 unit SPythonSystem;
 
-{$reference '%GAC%\System.dll'}
-{$reference '%GAC%\mscorlib.dll'}
-{$reference '%GAC%\System.Core.dll'}
-{$reference '%GAC%\System.Numerics.dll'}
+// В SPython данной версии нет возможности использовать пространства имен
+// {$reference '%GAC%\System.dll'}
+// {$reference '%GAC%\mscorlib.dll'}
+// {$reference '%GAC%\System.Core.dll'}
+// {$reference '%GAC%\System.Numerics.dll'}
 
 interface
 


### PR DESCRIPTION
В основном здесь избавление от legacy кода. В частности, в Intellisense закомментирована поддержка случая uses *какой-то тип .NET*, поскольку основной компилятор такой случай не поддерживает.