### PR TITLE
Рефакторинг: устранение `Hashtable`

### DIFF
--- a/CodeCompletion/DomConverter.cs
+++ b/CodeCompletion/DomConverter.cs
@@ -42,7 +42,7 @@ namespace CodeCompletion
 
         // TODO: Требуется адаптировать к многоязычности  EVA
         public static SymInfo[] standard_units;
-        private Hashtable cur_used_assemblies;
+        private HashSet<Assembly> cur_used_assemblies;
         public CompilationUnit unit;
 
         private void InitModules()
@@ -1230,7 +1230,7 @@ namespace CodeCompletion
             return false;
         }
 
-        private Hashtable tmp_cur_used_assemblies;
+        private HashSet<Assembly> tmp_cur_used_assemblies;
 
         //kazhdaja programma mozhet imet svoj spisok podkluchaemyh sborok, 
         //poetomu nado sohranat i vosstanavlivat tekushij kesh sborok

--- a/CodeCompletion/DomSyntaxTreeVisitor.cs
+++ b/CodeCompletion/DomSyntaxTreeVisitor.cs
@@ -40,7 +40,7 @@ namespace CodeCompletion
         private static Compiler compiler;
         public static bool use_semantic_for_intellisense;
         private Dictionary<method_call, SymScope> method_call_cache = new Dictionary<method_call, SymScope>();
-        public Hashtable cur_used_assemblies;
+        public HashSet<Assembly> cur_used_assemblies;
 
         public DomSyntaxTreeVisitor(DomConverter converter)
 		{
@@ -69,7 +69,7 @@ namespace CodeCompletion
                 //throw e;
             	//System.Diagnostics.Debug.WriteLine(e.StackTrace);
             }
-            cur_used_assemblies = (Hashtable)PascalABCCompiler.NetHelper.NetHelper.cur_used_assemblies.Clone();
+            cur_used_assemblies = new HashSet<Assembly>(PascalABCCompiler.NetHelper.NetHelper.cur_used_assemblies);
             if (use_semantic_for_intellisense && !parse_only_interface)
             try
             {

--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -156,7 +156,6 @@ using System.Linq;
 using System.Reflection;
 
 using Languages.Facade;
-using SyntaxVisitors;
 
 namespace PascalABCCompiler
 {
@@ -680,7 +679,7 @@ namespace PascalABCCompiler
         /// </summary>
         private List<CompilationUnit> UnitsToCompileDelayedList = new List<CompilationUnit>();
         
-        public Hashtable RecompileList = new Hashtable(StringComparer.OrdinalIgnoreCase);
+        public HashSet<string> RecompileList = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         private CompilationUnit currentCompilationUnit = null;
         
@@ -4005,7 +4004,7 @@ namespace PascalABCCompiler
                 {
                     if (UnitTable[Path.ChangeExtension(used_unit_fname, null)] != null) return true;
                     need = true;
-                    RecompileList[pcu_name] = pcu_name;
+                    RecompileList.Add(pcu_name);
                 }
             }
             if (need) return true;
@@ -4027,7 +4026,7 @@ namespace PascalABCCompiler
                     pr.AddAlreadyCompiledUnit(pcu_name2);
                     return true;
                 }
-                if (RecompileList.ContainsKey(pcu_name2))
+                if (RecompileList.Contains(pcu_name2))
                 {
                     return true;
                 }

--- a/Localization/StringResourcesLanguage.cs
+++ b/Localization/StringResourcesLanguage.cs
@@ -2,8 +2,6 @@
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
 using System;
 using System.Collections.Generic;
-using System.Collections;
-using System.Text;
 using System.IO;
 
 namespace PascalABCCompiler
@@ -11,9 +9,9 @@ namespace PascalABCCompiler
 
     public class StringResourcesLanguage
     {
-        private static Hashtable AccessibleLanguagesHashtable = new Hashtable(StringComparer.OrdinalIgnoreCase);
-        private static Hashtable AccessibleTwoLetterISOHashtable = new Hashtable(StringComparer.OrdinalIgnoreCase);
-        private static Hashtable AccessibleLCIDHashtable = new Hashtable(StringComparer.OrdinalIgnoreCase);
+        private static Dictionary<string, string> AccessibleLanguagesHashtable = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private static Dictionary<string, string> AccessibleTwoLetterISOHashtable = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private static Dictionary<string, string> AccessibleLCIDHashtable = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private static List<string> accessibleLanguages = new List<string>();
         private static string DefaultLanguage = null;
         private static string DefaultTwoLetterISO = null;
@@ -119,11 +117,11 @@ namespace PascalABCCompiler
             get{return currentLanguageName;}
             set
             {
-                if (AccessibleLanguagesHashtable[value] == null) return;
+                if (!AccessibleLanguagesHashtable.ContainsKey(value)) return;
                 currentLanguageName = value;
-                currentTwoLetterISO = AccessibleTwoLetterISOHashtable[value] as string;
-                currentLCID = AccessibleLCIDHashtable[currentTwoLetterISO] as string;
-                StringResources.ResDirectoryName = AccessibleLanguagesHashtable[currentLanguageName] as string;
+                currentTwoLetterISO = AccessibleTwoLetterISOHashtable[value];
+                currentLCID = AccessibleLCIDHashtable[currentTwoLetterISO];
+                StringResources.ResDirectoryName = AccessibleLanguagesHashtable[currentLanguageName];
                 StringResources.UpdateObjectsText();
             }
         }
@@ -146,7 +144,8 @@ namespace PascalABCCompiler
 
         public static string GetLCIDByTwoLetterISO(string iso)
         {
-            return AccessibleLCIDHashtable[iso] as string;
+            AccessibleLCIDHashtable.TryGetValue(iso, out var result);
+            return result;
         }
     }
 }

--- a/NETGenerator/Helpers.cs
+++ b/NETGenerator/Helpers.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Collections;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace PascalABCCompiler.NETGenerator {
 	
@@ -515,11 +516,11 @@ namespace PascalABCCompiler.NETGenerator {
 	
 	public class Helper {
 		public Hashtable defs=new Hashtable();
-        private Hashtable processing_types = new Hashtable();
+        private HashSet<ICommonTypeNode> processing_types = new HashSet<ICommonTypeNode>();
 		private MethodInfo arr_mi=null;
-		private Hashtable pas_defs = new Hashtable();
-        private Hashtable memoized_exprs = new Hashtable();
-		private Hashtable dummy_methods = new Hashtable();
+        private Dictionary<ITypeNode, Type> pas_defs = new Dictionary<ITypeNode, Type>();
+        private Dictionary<IExpressionNode, LocalBuilder> memoized_exprs = new Dictionary<IExpressionNode, LocalBuilder>();
+        private Dictionary<TypeBuilder, MethodBuilder> dummy_methods = new Dictionary<TypeBuilder, MethodBuilder>();
 
 		public Helper() {}
 		
@@ -528,9 +529,9 @@ namespace PascalABCCompiler.NETGenerator {
 			dummy_methods[tb] = mb;
         }
 
-		public MethodBuilder GetDummyMethod(TypeBuilder tb)
+        public MethodBuilder GetDummyMethod(TypeBuilder tb)
         {
-			return dummy_methods[tb] as MethodBuilder;
+            return dummy_methods[tb];
         }
 
 		public void AddPascalTypeReference(ITypeNode tn, Type t)
@@ -540,7 +541,8 @@ namespace PascalABCCompiler.NETGenerator {
 		
 		public Type GetPascalTypeReference(ITypeNode tn)
 		{
-			return pas_defs[tn] as Type;
+			pas_defs.TryGetValue(tn, out var result);
+			return result;
 		}
 		
 		public ConstInfo AddConstant(IConstantDefinitionNode cnst, FieldBuilder fb)
@@ -872,14 +874,14 @@ namespace PascalABCCompiler.NETGenerator {
             return null;
         }
 
-		public void SetAsProcessing(ICommonTypeNode type)
+        public void SetAsProcessing(ICommonTypeNode type)
         {
-            processing_types[type] = true;
+            processing_types.Add(type);
         }
 
         public bool IsProcessing(ICommonTypeNode type)
         {
-            return processing_types[type] != null;
+            return processing_types.Contains(type);
         }
 
         public void LinkExpressionToLocalBuilder(IExpressionNode expr, LocalBuilder lb)
@@ -889,7 +891,8 @@ namespace PascalABCCompiler.NETGenerator {
 
         public LocalBuilder GetLocalBuilderForExpression(IExpressionNode expr)
         {
-            return memoized_exprs[expr] as LocalBuilder;
+            memoized_exprs.TryGetValue(expr, out var result);
+            return result;
         }
 
         //получение типа
@@ -1050,6 +1053,4 @@ namespace PascalABCCompiler.NETGenerator {
             return m;
         }
     }
-	
-	
 }

--- a/NETGenerator/NETGenegratorTools.cs
+++ b/NETGenerator/NETGenegratorTools.cs
@@ -2,9 +2,7 @@
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Reflection.Emit;
-using System.Collections;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -19,7 +17,7 @@ namespace PascalABCCompiler.NETGenerator
         public static TypeInfo string_type;
         public static TypeInfo byte_type;
         public static Type ExceptionType = typeof(Exception);
-        public static Type VoidType =   typeof(void);
+        public static Type VoidType = typeof(void);
         public static Type StringType = typeof(string);
         public static Type ObjectType = typeof(object);
         public static Type MonitorType = typeof(System.Threading.Monitor);
@@ -46,7 +44,7 @@ namespace PascalABCCompiler.NETGenerator
         public static Type DoubleType = typeof(Double);
         public static Type GCHandleType = typeof(GCHandle);
         public static Type MarshalType = typeof(Marshal);
-        public static Type TypeType =   typeof(Type);
+        public static Type TypeType = typeof(Type);
         public static Type ValueType = typeof(ValueType);
         public static Type IEnumerableType = typeof(System.Collections.IEnumerable);
         public static Type IEnumeratorType = typeof(System.Collections.IEnumerator);
@@ -54,13 +52,13 @@ namespace PascalABCCompiler.NETGenerator
         public static Type IEnumerableGenericType = typeof(System.Collections.Generic.IEnumerable<>);
         public static Type IEnumeratorGenericType = typeof(System.Collections.Generic.IEnumerator<>);
 
-        private static Hashtable types;
-        private static Hashtable sizes;
+        private static HashSet<Type> types;
+        private static Dictionary<Type, int> sizes;
         public static MethodInfo ArrayCopyMethod;
         public static MethodInfo GetTypeFromHandleMethod;
-		public static MethodInfo ResizeMethod;
+        public static MethodInfo ResizeMethod;
         public static MethodInfo GCHandleFreeMethod;
-		public static MethodInfo StringNullOrEmptyMethod;
+        public static MethodInfo StringNullOrEmptyMethod;
         public static MethodInfo UnsizedArrayCreateMethodTemplate = null;
         public static MethodInfo GCHandleAlloc;
         public static MethodInfo GCHandleAllocPinned;
@@ -86,34 +84,30 @@ namespace PascalABCCompiler.NETGenerator
             char_type = new TypeInfo(typeof(char));
             string_type = new TypeInfo(typeof(string));
             byte_type = new TypeInfo(typeof(byte));
-            
-            types = new Hashtable();
-            types[BoolType] = BoolType;
-            types[SByteType] = SByteType;
-            types[ByteType] = ByteType;
-            types[CharType] = CharType;
-            types[Int16Type] = Int16Type;
-            types[Int32Type] = Int32Type;
-            types[Int64Type] = Int64Type;
-            types[UInt16Type] = UInt16Type;
-            types[UInt32Type] = UInt32Type;
-            types[UInt64Type] = UInt64Type;
-            types[SingleType] = SingleType;
-            types[DoubleType] = DoubleType;
 
-            sizes = new Hashtable();
-            sizes[BoolType] = sizeof(Boolean);
-            sizes[SByteType] = sizeof(SByte);
-            sizes[ByteType] = sizeof(Byte);
-            sizes[CharType] = sizeof(Char);
-            sizes[Int16Type] = sizeof(Int16);
-            sizes[Int32Type] = sizeof(Int32);
-            sizes[Int64Type] = sizeof(Int64);
-            sizes[UInt16Type] = sizeof(UInt16);
-            sizes[UInt32Type] = sizeof(UInt32);
-            sizes[UInt64Type] = sizeof(UInt64);
-            sizes[SingleType] = sizeof(Single);
-            sizes[DoubleType] = sizeof(Double);
+            types = new HashSet<Type>()
+            {
+                BoolType, SByteType, ByteType, CharType,
+                Int16Type, Int32Type, Int64Type,
+                UInt16Type, UInt32Type, UInt64Type,
+                SingleType, DoubleType
+            };
+
+            sizes = new Dictionary<Type, int>
+            {
+                [BoolType] = sizeof(Boolean),
+                [SByteType] = sizeof(SByte),
+                [ByteType] = sizeof(Byte),
+                [CharType] = sizeof(Char),
+                [Int16Type] = sizeof(Int16),
+                [Int32Type] = sizeof(Int32),
+                [Int64Type] = sizeof(Int64),
+                [UInt16Type] = sizeof(UInt16),
+                [UInt32Type] = sizeof(UInt32),
+                [UInt64Type] = sizeof(UInt64),
+                [SingleType] = sizeof(Single),
+                [DoubleType] = sizeof(Double)
+            };
             //sizes[UIntPtr] = sizeof(UIntPtr);
             
             //types[TypeType] = TypeType;
@@ -133,12 +127,12 @@ namespace PascalABCCompiler.NETGenerator
 
         public static bool IsStandType(Type t)
         {
-            return types[t] != null;
+            return types.Contains(t);
         }
 
         public static int GetPrimitiveTypeSize(Type PrimitiveType)
         {
-            return (int)sizes[PrimitiveType];
+            return sizes[PrimitiveType];
         }
     }
 

--- a/Optimizer/OptimizerTools.cs
+++ b/Optimizer/OptimizerTools.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Ivan Bondarev, Stanislav Mikhalkovich (for details please see \doc\copyright.txt)
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
-using System;
 using System.Collections.Generic;
-using System.Text;
 using PascalABCCompiler.TreeRealization;
 using System.Collections;
 
@@ -37,8 +35,8 @@ namespace PascalABCCompiler
     public class OptimizerHelper
     {
         private Hashtable ht = new Hashtable();
-        private Hashtable warns = new Hashtable();
-        private Hashtable ext_funcs = new Hashtable();
+        private Dictionary<var_definition_node, List<CompilerWarningWithLocation>> warns = new Dictionary<var_definition_node, List<CompilerWarningWithLocation>>();
+        private HashSet<common_function_node> ext_funcs = new HashSet<common_function_node>();
 
         public void AddVariable(var_definition_node vdn)
         {
@@ -76,8 +74,7 @@ namespace PascalABCCompiler
 
         public void AddTempWarning(var_definition_node vdn, CompilerWarningWithLocation cw)
         {
-            List<CompilerWarningWithLocation> lst = (List<CompilerWarningWithLocation>)warns[vdn];
-            if (lst == null)
+            if ( !warns.TryGetValue(vdn, out var lst) )
             {
                 lst = new List<CompilerWarningWithLocation>();
                 warns[vdn] = lst;
@@ -87,18 +84,18 @@ namespace PascalABCCompiler
 
         public void AddRealWarning(var_definition_node vdn, List<CompilerWarningWithLocation> cw)
         {
-            List<CompilerWarningWithLocation> lst = (List<CompilerWarningWithLocation>)warns[vdn];
+            List<CompilerWarningWithLocation> lst = warns[vdn];
             cw.AddRange(lst);
         }
 
         public void MarkAsExternal(common_function_node cfn)
         {
-            ext_funcs[cfn] = cfn;
+            ext_funcs.Add(cfn);
         }
 
         public bool IsExternal(common_function_node cfn)
         {
-            return ext_funcs[cfn] != null;
+            return ext_funcs.Contains(cfn);
         }
     }
 }

--- a/ParserTools/XmlDocs.cs
+++ b/ParserTools/XmlDocs.cs
@@ -1,25 +1,23 @@
 ﻿// Copyright (c) Ivan Bondarev, Stanislav Mikhalkovich (for details please see \doc\copyright.txt)
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Xml;
 using System.Reflection;
 using System.Text;
-using System.Globalization;
 
 namespace CodeCompletionTools
 {
 	
 	public partial class AssemblyDocCache
 	{
-		private static Hashtable ht=new Hashtable();
+        private static Dictionary<Assembly, XmlDoc> ht = new Dictionary<Assembly, XmlDoc>();
 
         public static string Load(Assembly a, string path)
         {
-            if (ht[a] != null) return null;
+            if (!ht.ContainsKey(a)) return null;
             string dir;
             if (string.IsNullOrEmpty(a.Location))
             	dir = path;
@@ -177,7 +175,7 @@ namespace CodeCompletionTools
 		
 		public static string GetDocumentation(Type t)
 		{
-			XmlDoc xdoc = (XmlDoc)ht[t.Assembly];
+			ht.TryGetValue(t.Assembly, out var xdoc);
 			try
 			{
 				if (xdoc != null)
@@ -195,7 +193,7 @@ namespace CodeCompletionTools
 
         public static string GetFullDocumentation(Type t)
         {
-            XmlDoc xdoc = (XmlDoc)ht[t.Assembly];
+            ht.TryGetValue(t.Assembly, out var xdoc);
             try
             {
                 if (xdoc != null)
@@ -277,11 +275,11 @@ namespace CodeCompletionTools
             return sb.ToString();
         }
 		
-		public static string GetDocumentation(ConstructorInfo mi)
-		{
+        public static string GetDocumentation(ConstructorInfo mi)
+        {
             try
             {
-                XmlDoc xdoc = (XmlDoc)ht[mi.DeclaringType.Assembly];
+                ht.TryGetValue(mi.DeclaringType.Assembly, out var xdoc);
                 if (xdoc != null)
                 {
                     string s = GetNormalHint(xdoc.GetDocumentation("M:" + mi.DeclaringType.FullName + ".#ctor" + GetParamNames(mi), false));
@@ -292,14 +290,14 @@ namespace CodeCompletionTools
             {
 
             }
-			return "";
-		}
+            return "";
+        }
 
         public static string GetFullDocumentation(ConstructorInfo mi)
         {
             try
             {
-                XmlDoc xdoc = (XmlDoc)ht[mi.DeclaringType.Assembly];
+                ht.TryGetValue(mi.DeclaringType.Assembly, out var xdoc);
                 if (xdoc != null)
                 {
                     return xdoc.GetDocumentation("M:" + mi.DeclaringType.FullName + ".#ctor" + GetParamNames(mi), false);
@@ -316,7 +314,7 @@ namespace CodeCompletionTools
 		{
 			try
 			{
-				XmlDoc xdoc = (XmlDoc)ht[fi.DeclaringType.Assembly];
+				ht.TryGetValue(fi.DeclaringType.Assembly, out var xdoc);
 				if (xdoc != null)
 				{
 					string s = GetNormalHint(xdoc.GetDocumentation("F:"+fi.DeclaringType.FullName+"."+fi.Name,false));
@@ -334,7 +332,7 @@ namespace CodeCompletionTools
         {
             try
             {
-                XmlDoc xdoc = (XmlDoc)ht[fi.DeclaringType.Assembly];
+                ht.TryGetValue(fi.DeclaringType.Assembly, out var xdoc);
                 if (xdoc != null)
                 {
                     return xdoc.GetDocumentation("F:" + fi.DeclaringType.FullName + "." + fi.Name, false);
@@ -351,7 +349,7 @@ namespace CodeCompletionTools
 		{
 			try
 			{
-				XmlDoc xdoc = (XmlDoc)ht[pi.DeclaringType.Assembly];
+				ht.TryGetValue(pi.DeclaringType.Assembly, out var xdoc);
 				if (xdoc != null)
 				{
 					string s = GetNormalHint(xdoc.GetDocumentation("P:"+pi.DeclaringType.FullName+"."+pi.Name,false));
@@ -369,7 +367,7 @@ namespace CodeCompletionTools
         {
             try
             {
-                XmlDoc xdoc = (XmlDoc)ht[pi.DeclaringType.Assembly];
+                ht.TryGetValue(pi.DeclaringType.Assembly, out var xdoc);
                 if (xdoc != null)
                 {
                     return xdoc.GetDocumentation("P:" + pi.DeclaringType.FullName + "." + pi.Name, false);
@@ -386,7 +384,7 @@ namespace CodeCompletionTools
 		{
 			try
 			{
-				XmlDoc xdoc = (XmlDoc)ht[ei.DeclaringType.Assembly];
+				ht.TryGetValue(ei.DeclaringType.Assembly, out var xdoc);
 				if (xdoc != null)
 				{
 					string s = GetNormalHint(xdoc.GetDocumentation("E:"+ei.DeclaringType.FullName+"."+ei.Name,false));
@@ -404,7 +402,7 @@ namespace CodeCompletionTools
         {
             try
             {
-                XmlDoc xdoc = (XmlDoc)ht[ei.DeclaringType.Assembly];
+                ht.TryGetValue(ei.DeclaringType.Assembly, out var xdoc);
                 if (xdoc != null)
                 {
                     return xdoc.GetDocumentation("E:" + ei.DeclaringType.FullName + "." + ei.Name, false);
@@ -429,7 +427,7 @@ namespace CodeCompletionTools
 		{
 			try
 			{
-				XmlDoc xdoc = (XmlDoc)ht[mi.DeclaringType.Assembly];
+				ht.TryGetValue(mi.DeclaringType.Assembly, out var xdoc);
 				if (xdoc != null)
 				{
 					string generic_add = GetGenericAddString(mi);
@@ -448,7 +446,7 @@ namespace CodeCompletionTools
         {
             try
             {
-                XmlDoc xdoc = (XmlDoc)ht[mi.DeclaringType.Assembly];
+                ht.TryGetValue(mi.DeclaringType.Assembly, out var xdoc);
                 if (xdoc != null)
                 {
                     string generic_add = GetGenericAddString(mi);
@@ -470,7 +468,7 @@ namespace CodeCompletionTools
 		
 		public static string GetDocumentation(Assembly a, string descr)
 		{
-			XmlDoc xdoc = (XmlDoc)ht[a];
+			ht.TryGetValue(a, out var xdoc);
 			try
 			{
 				if (xdoc != null)

--- a/TreeConverter/SystemLib/StaticSystemLib.cs
+++ b/TreeConverter/SystemLib/StaticSystemLib.cs
@@ -18,7 +18,6 @@ namespace PascalABCCompiler.SystemLibrary
     //TODO: Все базовые методы должны быть определены здесь как статические и использовать их отсюда, а не создавать их по два раза.
     public static class SystemLibrary
     {
-    	
         private static compiled_type_node _bool_type;
         private static compiled_type_node _byte_type;
         private static compiled_type_node _sbyte_type;
@@ -95,7 +94,7 @@ namespace PascalABCCompiler.SystemLibrary
 		private static SymbolTable.TreeConverterSymbolTable _symtab;
         private static System.Collections.Generic.Dictionary<SemanticTree.basic_function_type, basic_function_node> ht = new System.Collections.Generic.Dictionary<SemanticTree.basic_function_type, basic_function_node>();
 
-        private static System.Collections.Hashtable writable_in_typed_files_types = new System.Collections.Hashtable();
+        private static HashSet<compiled_type_node> writable_in_typed_files_types = new HashSet<compiled_type_node>();
 
         private static string_const_node _empty_string;
 
@@ -2079,18 +2078,18 @@ namespace PascalABCCompiler.SystemLibrary
             // То есть, это было неправильное исправление 
 
             writable_in_typed_files_types.Clear();
-            writable_in_typed_files_types.Add(_bool_type, _bool_type);
-            writable_in_typed_files_types.Add(_byte_type, _byte_type);
-            writable_in_typed_files_types.Add(_sbyte_type, _sbyte_type);
-            writable_in_typed_files_types.Add(_short_type, _short_type);
-            writable_in_typed_files_types.Add(_ushort_type, _ushort_type);
-            writable_in_typed_files_types.Add(_integer_type, _integer_type);
-            writable_in_typed_files_types.Add(_uint_type, _uint_type);
-            writable_in_typed_files_types.Add(_int64_type, _int64_type);
-            writable_in_typed_files_types.Add(_uint64_type, _uint64_type);
-            writable_in_typed_files_types.Add(_double_type, _double_type);
-            writable_in_typed_files_types.Add(_char_type, _char_type);
-            writable_in_typed_files_types.Add(_float_type, _float_type);
+            writable_in_typed_files_types.Add(_bool_type);
+            writable_in_typed_files_types.Add(_byte_type);
+            writable_in_typed_files_types.Add(_sbyte_type);
+            writable_in_typed_files_types.Add(_short_type);
+            writable_in_typed_files_types.Add(_ushort_type);
+            writable_in_typed_files_types.Add(_integer_type);
+            writable_in_typed_files_types.Add(_uint_type);
+            writable_in_typed_files_types.Add(_int64_type);
+            writable_in_typed_files_types.Add(_uint64_type);
+            writable_in_typed_files_types.Add(_double_type);
+            writable_in_typed_files_types.Add(_char_type);
+            writable_in_typed_files_types.Add(_float_type);
             
             foreach (type_node tn in wait_add_ref_list)
             	init_reference_type(tn);
@@ -2120,7 +2119,7 @@ namespace PascalABCCompiler.SystemLibrary
 
         public static bool CanUseThisTypeForTypedFiles(type_node tn)
         {
-            return writable_in_typed_files_types[tn] != null;
+            return writable_in_typed_files_types.Contains(tn);
         }
 
         private static void add_std_convertions()

--- a/TreeConverter/TreeConversion/syntax_tree_visitor.cs
+++ b/TreeConverter/TreeConversion/syntax_tree_visitor.cs
@@ -12761,7 +12761,7 @@ namespace PascalABCCompiler.TreeConverter
         {
             if (td.attributes != null)
             {
-                Hashtable ht = new Hashtable();
+                var ht = new HashSet<type_node>();
                 foreach (SyntaxTree.simple_attribute_list sal in td.attributes.attributes)
                     for (int j = 0; j < sal.attributes.Count; j++)
                     {
@@ -12784,7 +12784,7 @@ namespace PascalABCCompiler.TreeConverter
                             AddError(get_location(attr), "DUPLICATE_ATTRIBUTE_{0}_APPLICATION", tn.name);
                         }
                         else
-                            ht[tn] = tn;
+                            ht.Add(tn);
                         SemanticTree.attribute_qualifier_kind qualifier = SemanticTree.attribute_qualifier_kind.none_kind;
                         if (attr.qualifier != null)
                             if (j == 0)
@@ -12928,7 +12928,7 @@ namespace PascalABCCompiler.TreeConverter
         {
             if (cun.attributes != null)
             {
-                Hashtable ht = new Hashtable();
+                var ht = new HashSet<type_node>();
                 foreach (SyntaxTree.simple_attribute_list sal in un.attributes.attributes)
                     for (int j = 0; j < sal.attributes.Count; j++)
                     {
@@ -12951,7 +12951,7 @@ namespace PascalABCCompiler.TreeConverter
                             AddError(get_location(attr), "DUPLICATE_ATTRIBUTE_{0}_APPLICATION", tn.name);
                         }
                         else
-                            ht[tn] = tn;
+                            ht.Add(tn);
                         SemanticTree.attribute_qualifier_kind qualifier = SemanticTree.attribute_qualifier_kind.none_kind;
                         if (attr.qualifier != null)
                             if (j == 0)
@@ -13258,7 +13258,7 @@ namespace PascalABCCompiler.TreeConverter
         //Добавляет ограничители для параметра шаблона
         private void add_generic_eliminations(common_type_node param, List<SyntaxTree.type_definition> specificators)
         {
-            Hashtable used_interfs = new Hashtable();
+            var used_interfs = new HashSet<type_node>();
             // System.Enum это класс, но его наследники - записи
             // Если указать "where T: Enum, record" - станет нельзя применять T=Enum, с ошибкой что Enum не запись
             // Но чтобы в секции where override метода можно было указать record без System.Enum
@@ -13320,13 +13320,13 @@ namespace PascalABCCompiler.TreeConverter
                         //    param.is_class = true;
                         if (spec_type.IsInterface)
                         {
-                            if (used_interfs[spec_type] != null)
+                            if (used_interfs.Contains(spec_type))
                             {
                                 AddError(get_location(specificators[i]), "INTERFACE_{0}_ALREADY_ADDED_TO_IMPLEMENTING_LIST", spec_type.PrintableName);
                             }
                             else
                             {
-                                used_interfs.Add(spec_type, spec_type);
+                                used_interfs.Add(spec_type);
                             }
                             //Добавляем интерфейс
                             type_table.AddInterface(param, spec_type, get_location(specificators[i]));
@@ -13358,7 +13358,7 @@ namespace PascalABCCompiler.TreeConverter
                                 {
                                     foreach (type_node tn in spec_type.ImplementingInterfaces)
                                     {
-                                        used_interfs.Add(tn, tn);
+                                        used_interfs.Add(tn);
                                         type_table.AddInterface(param, tn, get_location(specificators[i]));
                                     }
                                 }

--- a/TreeConverter/TreeRealization/programs.cs
+++ b/TreeConverter/TreeRealization/programs.cs
@@ -100,8 +100,8 @@ namespace PascalABCCompiler.TreeRealization
             common_namespace_node[] ret = new common_namespace_node[namespaces.Count];
             namespaces.Values.CopyTo(ret, 0);
             return ret;*/
-            System.Collections.Hashtable ht = new System.Collections.Hashtable();
-            System.Collections.ArrayList al = new System.Collections.ArrayList();
+            var ht = new Dictionary<string, common_namespace_node>();
+            var al = new List<common_namespace_node>();
             common_namespace_node main_cnn = null;
             foreach (common_unit_node un in units)
             {
@@ -109,7 +109,7 @@ namespace PascalABCCompiler.TreeRealization
                 {
                     //if (cnn.namespace_full_name != "")
                     //{
-                        if (ht[cnn.namespace_name] == null)
+                        if (!ht.ContainsKey(cnn.namespace_name))
                         {
                             al.Add(cnn); ht[cnn.namespace_name] = cnn;
                         }
@@ -160,15 +160,15 @@ namespace PascalABCCompiler.TreeRealization
                 if (_namespaces == null)
                 {
                     _namespaces = get_units_namespaces(_units);
-                    System.Collections.Hashtable ns_ht = new System.Collections.Hashtable();
+                    var ns_ht = new HashSet<string>();
                     foreach (common_unit_node un in units)
             		{
             			foreach (string s in un.used_namespaces)
             			{
-            				if (!ns_ht.ContainsKey(s))
+            				if (!ns_ht.Contains(s))
             				{
             					this._used_namespaces.Add(s);
-            					ns_ht.Add(s,s);
+            					ns_ht.Add(s);
             				}
             			}
                     }


### PR DESCRIPTION
Заменил не типизированный `Hashtable` на типизированные `HashSet<T>` и `Dictionary<TKey, TValue>` во многих местах проекта

В некоторых местах остаётся `Hashtable` тк установить наиболее общий тип для типоаргументов не так просто