### PR TITLE
Revert description refreshing for generic function instances

### DIFF
--- a/CodeCompletion/DomConverter.cs
+++ b/CodeCompletion/DomConverter.cs
@@ -1022,12 +1022,18 @@ namespace CodeCompletion
                     ss.si.description = (ss as ElementScope).sc.Description;
                 }
                 // к сожалению, при текущей реализации обновлять описание для инстансов функций не представляется возможным
-                // описания типов аргументов составляются неправильно  EVA
-                else if (!(ss is ProcScope procScope) || !procScope.OfTypeInstance)
+                // описания типов аргументов составляются неправильно
+                // обновляем описание для исходной функции EVA
+                else if (ss is ProcScope procScope && procScope.original_function != null)
+                {
+                    // обновление описания
+                    ss = procScope.original_function.WithRefreshedDescription();
+                }
+                else
                 {
                     // обновление описания
                     ss = ss.WithRefreshedDescription();
-                }  
+                }
 
                 try
                 {
@@ -1066,11 +1072,11 @@ namespace CodeCompletion
                     }
                 }
                 catch (Exception e)
-                    {
+                {
 #if DEBUG
-                        File.AppendAllText("log.txt", e.Message + Environment.NewLine + e.StackTrace + Environment.NewLine);
+                    File.AppendAllText("log.txt", e.Message + Environment.NewLine + e.StackTrace + Environment.NewLine);
 #endif
-                    }
+                }
                 RestoreCurrentUsedAssemblies();
                 string description = ss.si.description;
                 if (description != null)


### PR DESCRIPTION
Оказалось, что обновлять описание для инстансов generic функций не приводит ни к чему хорошему, поскольку типы реальных параметров получают некорректное описание после вывода типов и обновления описания. Например, при наведении на `ArrGen(1, i -> True)` мы получаем следующую картину. Пришлось убрать обновление описания для случая инстансов шаблонных функций.
<img width="513" height="129" alt="image" src="https://github.com/user-attachments/assets/adc22608-c2bc-4b95-a251-c1bdd3c661dc" />
