### PR TITLE
Отключение семантического Intellisense для SPython

### DIFF
--- a/CodeCompletion/DomSyntaxTreeVisitor.cs
+++ b/CodeCompletion/DomSyntaxTreeVisitor.cs
@@ -70,7 +70,9 @@ namespace CodeCompletion
             	//System.Diagnostics.Debug.WriteLine(e.StackTrace);
             }
             cur_used_assemblies = new HashSet<Assembly>(PascalABCCompiler.NetHelper.NetHelper.cur_used_assemblies);
-            if (use_semantic_for_intellisense && !parse_only_interface)
+            
+            if (use_semantic_for_intellisense && !parse_only_interface 
+                && currentUnitLanguage.LanguageInformation.SemanticIntellisenseIsSupported)
             try
             {
                 CorrectTreeWithSemantic(cu);

--- a/LanguagePlugins/SPython/SPythonLanguageInfo/SPythonLanguageInformation.cs
+++ b/LanguagePlugins/SPython/SPythonLanguageInfo/SPythonLanguageInformation.cs
@@ -1,11 +1,9 @@
-﻿using PascalABCCompiler;
-using PascalABCCompiler.Parsers;
+﻿using PascalABCCompiler.Parsers;
 using PascalABCCompiler.ParserTools.Directives;
 using PascalABCCompiler.SyntaxTree;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 
 namespace Languages.SPython.Frontend.Data
@@ -21,6 +19,8 @@ namespace Languages.SPython.Frontend.Data
         public override string[] FilesExtensions => new string[] { ".pys" };
 
         public override string[] SystemUnitNames => new string[] { "SPythonSystem", "SPythonHidden", "SPythonSystemPys" };
+
+        public override bool SemanticIntellisenseIsSupported => false;
 
         public override bool ApplySyntaxTreeConvertersForIntellisense => true;
 
@@ -54,7 +54,7 @@ namespace Languages.SPython.Frontend.Data
 
         public override bool AddStandardUnitNamesToUserScope => false;
 
-        public override bool AddStandardNetNamespacesToUserScope => true;
+        public override bool AddStandardNetNamespacesToUserScope => false;
 
         public override bool UsesFunctionsOverlappingSourceContext => true;
 

--- a/ParserTools/ParserTools/BaseLanguageInformation.cs
+++ b/ParserTools/ParserTools/BaseLanguageInformation.cs
@@ -44,6 +44,8 @@ namespace PascalABCCompiler.Parsers
         public abstract string ProcedureName { get; }
         public abstract string FunctionName { get; }
 
+        public abstract bool SemanticIntellisenseIsSupported { get; }
+
         public abstract bool ApplySyntaxTreeConvertersForIntellisense { get; }
 
         public abstract bool IncludeDotNetEntities { get; }

--- a/ParserTools/ParserTools/ILanguageInformation.cs
+++ b/ParserTools/ParserTools/ILanguageInformation.cs
@@ -171,6 +171,11 @@ namespace PascalABCCompiler.Parsers
         int FindParamDelimForIndexer(string descriptionAfterOpeningParenthesis, int number);
 
         /// <summary>
+        /// Реализовано ли использование компилятора для Intellisense
+        /// </summary>
+        bool SemanticIntellisenseIsSupported { get; }
+
+        /// <summary>
         /// Вызывать ли преобразователей синтаксического дерева в работе Intellisense
         /// </summary>
         bool ApplySyntaxTreeConvertersForIntellisense { get; }

--- a/PascalABCLanguageInfo/PascalABCLanguageInformation.cs
+++ b/PascalABCLanguageInfo/PascalABCLanguageInformation.cs
@@ -26,6 +26,8 @@ namespace Languages.Pascal.Frontend.Data
 
         public override string[] SystemUnitNames => StringConstants.pascalDefaultStandardModules;
 
+        public override bool SemanticIntellisenseIsSupported => true;
+
         public override bool ApplySyntaxTreeConvertersForIntellisense => false;
 
         protected IParser Parser


### PR DESCRIPTION
Семантический Intellisense (исправление типов, выведенных Intellisense, при помощи компилятора) не может поддерживаться в SPython на данный момент по причине того, что дерево конвертируется в Intellisense и повторный обход дерева в компиляторе портит его. Если же парсить дерево в компиляторе заново для SPython, то это все равно не поможет, потому что у вставляемых узлов не всегда задается location.