### PR TITLE
Исправление LastMaxBy - Update PABCSystem.pas

### DIFF
--- a/bin/Lib/PABCSystem.pas
+++ b/bin/Lib/PABCSystem.pas
@@ -11731,7 +11731,7 @@ begin
   begin
     var currentElement := enumerator.Current;
     var currentKey := keySelector(currentElement);
-    if comp.Compare(currentKey,maxKey) > 0 then
+    if comp.Compare(currentKey,maxKey) >= 0 then
     begin
       maxKey := currentKey;
       maxElement := currentElement; 


### PR DESCRIPTION
Если использовать >, то при равенстве ключей результат не обновляется — останется первый максимальный элемент. А нам нужно последний — поэтому >= — обязательно.