### PR TITLE
Рефакторинг: устранение `HashTable` [2]

### DIFF
--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -566,7 +566,7 @@ namespace PascalABCCompiler
             }
         }
 
-        private Hashtable BadNodesInSyntaxTree = new Hashtable();
+        private HashSet<SyntaxTree.syntax_tree_node> BadNodesInSyntaxTree = new HashSet<SyntaxTree.syntax_tree_node>();
 
         program_node semanticTree = null;
         public SemanticTree.IProgramNode SemanticTree
@@ -3505,7 +3505,7 @@ namespace PascalABCCompiler
                 currentUnit.syntax_error = errorsList[0] as SyntaxError;
                 foreach (Error er in errorsList)
                     if (er is SyntaxError && (er as SyntaxError).bad_node != null)
-                        BadNodesInSyntaxTree[(er as SyntaxError).bad_node] = er;
+                        BadNodesInSyntaxTree.Add((er as SyntaxError).bad_node);
             }
         }
 

--- a/TreeConverter/NetWrappers/NetHelper.cs
+++ b/TreeConverter/NetWrappers/NetHelper.cs
@@ -2,7 +2,6 @@
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
 using System;
 using PascalABCCompiler.SemanticTree;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -286,9 +285,9 @@ namespace PascalABCCompiler.NetHelper
 	
 	public static class NetHelper {
         private static Dictionary<string, Type> namespaces;
-        private static Hashtable types;
+        private static Dictionary<string, object> types;
         private static Dictionary<string, FoundInfo> type_search_cache;
-		private static Hashtable compiled_pascal_types;
+		private static Dictionary<string, object> compiled_pascal_types;
 		/*private static Hashtable methods;
 		private static Hashtable properties;
 		private static Hashtable fields;*/
@@ -298,7 +297,7 @@ namespace PascalABCCompiler.NetHelper
 		private static Dictionary<Type, Dictionary<string, List<MemberInfo>>> members;
 		//private static Hashtable meth_nodes;
 		private static Dictionary<PropertyInfo, compiled_property_node> prop_nodes;
-		private static Hashtable field_nodes;
+		private static Dictionary<MemberInfo, definition_node> field_nodes;
         private static Dictionary<ConstructorInfo, compiled_constructor_node> constr_nodes;
 		private static HashSet<Type> stand_types;
         private static Dictionary<Assembly, Dictionary<int, Type>> type_handles;
@@ -487,7 +486,7 @@ namespace PascalABCCompiler.NetHelper
                     TypeInfo ti = new TypeInfo(t, t.FullName);
                     types[t.FullName] = ti;
                     string short_name = t.Name;
-                    object o2 = types[short_name];
+                    types.TryGetValue(short_name, out object o2);
 
                     if (o2 == null)
                         types[short_name] = ti;
@@ -870,8 +869,8 @@ namespace PascalABCCompiler.NetHelper
             //interfaces = new Hashtable();
             //\ssyy-
             //types = new Hashtable(1024, CaseInsensitiveHashCodeProvider.Default, CaseInsensitiveComparer.Default);
-            types = new Hashtable(8096, StringComparer.CurrentCultureIgnoreCase);
-            compiled_pascal_types = new Hashtable(1024, StringComparer.CurrentCultureIgnoreCase);
+            types = new Dictionary<string, object>(8096, StringComparer.CurrentCultureIgnoreCase);
+            compiled_pascal_types = new Dictionary<string, object>(1024, StringComparer.CurrentCultureIgnoreCase);
             namespaces = new Dictionary<string, Type>(1024, StringComparer.CurrentCultureIgnoreCase);
             ass_name_cache = new Dictionary<string, Assembly>(1024, StringComparer.CurrentCultureIgnoreCase);
             assm_full_paths = new Dictionary<Assembly, string>();
@@ -884,7 +883,7 @@ namespace PascalABCCompiler.NetHelper
             assemblies = new HashSet<Assembly>();
             //meth_nodes = new Hashtable();
             prop_nodes = new Dictionary<PropertyInfo,compiled_property_node>();
-            field_nodes = new Hashtable();
+            field_nodes = new Dictionary<MemberInfo, definition_node>();
             constr_nodes = new Dictionary<ConstructorInfo, compiled_constructor_node>();
             stand_types = new HashSet<Type>();
             type_handles = new Dictionary<Assembly, Dictionary<int, Type>>();
@@ -1716,9 +1715,11 @@ namespace PascalABCCompiler.NetHelper
 
 		public static compiled_variable_definition GetFieldNode(FieldInfo pi)
 		{
-            compiled_variable_definition cpn = field_nodes[pi] as compiled_variable_definition;
-			if (cpn != null) 
+            compiled_variable_definition cpn;
+			if ( field_nodes.TryGetValue(pi, out var existingNode) ) 
 			{
+                cpn = (compiled_variable_definition)existingNode;
+
 				if (cpn.type is compiled_type_node)
 				return cpn;
 				if (PascalABCCompiler.TreeConverter.compilation_context.instance != null && PascalABCCompiler.TreeConverter.compilation_context.instance.syntax_tree_visitor.CompiledUnit != null && PascalABCCompiler.TreeConverter.compilation_context.instance.converted_namespace != null)
@@ -1840,12 +1841,13 @@ namespace PascalABCCompiler.NetHelper
         }
         public static compiled_class_constant_definition GetConstantFieldNode(FieldInfo fi)
         {
-            compiled_class_constant_definition cccd = field_nodes[fi] as compiled_class_constant_definition;
-            if (cccd != null) return cccd;
+            if ( field_nodes.TryGetValue(fi, out var existingNode) )
+                return (compiled_class_constant_definition)existingNode;
+
             constant_node cn = CreateConstantNode(fi.GetRawConstantValue());
             if (cn == null)
                 return null;
-            cccd = new compiled_class_constant_definition(fi, cn);
+            var cccd = new compiled_class_constant_definition(fi, cn);
             field_nodes[fi] = cccd;
             return cccd;
         }
@@ -1865,12 +1867,10 @@ namespace PascalABCCompiler.NetHelper
 
         public static compiled_event GetEvent(EventInfo ei)
         {
-            compiled_event ce = field_nodes[ei] as compiled_event;
-            if (ce != null)
-            {
-                return ce;
-            }
-            ce = new compiled_event(ei);
+            if ( field_nodes.TryGetValue(ei, out var existingNode) )
+                return (compiled_event)existingNode;
+
+            var ce = new compiled_event(ei);
             field_nodes[ei] = ce;
             return ce;
         }
@@ -1958,8 +1958,8 @@ namespace PascalABCCompiler.NetHelper
                 if (ti != null)
                     return ti.type;
             }
-			TypeInfo t = (TypeInfo)types[name];
-			if (t != null)
+
+			if (types.TryGetValue(name, out var temp) && temp is TypeInfo t)
             {
                 fi = new FoundInfo(true, t);
                 type_search_cache[name] = fi;
@@ -1981,8 +1981,7 @@ namespace PascalABCCompiler.NetHelper
 
         public static template_class FindCompiledTemplateType(string name)
         {
-            object o = compiled_pascal_types[name];
-            if (o != null)
+            if ( compiled_pascal_types.TryGetValue(name, out object o) )
             {
                 template_class tc = o as template_class;
                 if (tc == null && PascalABCCompiler.TreeConverter.compilation_context.instance != null && PascalABCCompiler.TreeConverter.compilation_context.instance.syntax_tree_visitor.CompiledUnit != null && PascalABCCompiler.TreeConverter.compilation_context.instance.converted_namespace != null)
@@ -2003,8 +2002,7 @@ namespace PascalABCCompiler.NetHelper
 
         public static type_node FindCompiledPascalType(string name)
         {
-            object o = compiled_pascal_types[name];
-            if (o != null)
+            if ( compiled_pascal_types.TryGetValue(name, out object o) )
             {
                 type_node tn = o as type_node;
                 if (tn == null && PascalABCCompiler.TreeConverter.compilation_context.instance != null && PascalABCCompiler.TreeConverter.compilation_context.instance.syntax_tree_visitor.CompiledUnit != null && PascalABCCompiler.TreeConverter.compilation_context.instance.converted_namespace != null)
@@ -2062,7 +2060,7 @@ namespace PascalABCCompiler.NetHelper
                     if (cur_used_assemblies.Contains(ti.type.Assembly))
                         return ti.type;
             }
-            object o = types[name];
+            types.TryGetValue(name, out object o);
             if (o == null)
             {
                 type_search_cache[name] = new FoundInfo(false);
@@ -2151,7 +2149,7 @@ namespace PascalABCCompiler.NetHelper
             }
             for (int i = 0; i < _unar.Count; i++)
             {
-                o = types[_unar[i].namespace_name + "." + name];
+                types.TryGetValue(_unar[i].namespace_name + "." + name, out o);
                 if (o == null)
                     continue;
                 if (o is TypeInfo)
@@ -2179,8 +2177,9 @@ namespace PascalABCCompiler.NetHelper
 		
 		public static Type FindTypeOrCreate(string name)
 		{
-			TypeInfo ti = types[name] as TypeInfo;
-			if (ti != null /*&& cur_used_assemblies.ContainsKey(t.Assembly)*/) return ti.type;
+            types.TryGetValue(name, out var tempTI);
+
+			if (tempTI is TypeInfo ti /*&& cur_used_assemblies.ContainsKey(t.Assembly)*/) return ti.type;
 			//ivan added - runtime types adding
 			Type t = Type.GetType(name, false, true);
             if (t == null)
@@ -2222,8 +2221,8 @@ namespace PascalABCCompiler.NetHelper
 				return typs;
 			foreach (string s in types.Keys)
 			{
-				TypeInfo ti = types[s] as TypeInfo;
-				if (ti != null)
+                types.TryGetValue(name, out var tempTI);
+				if (tempTI is TypeInfo ti)
 				if (string.Compare(ti.type.Namespace,name, true) == 0)
 				{
 					lst.Add(ti.type);

--- a/TreeConverter/OpenMP/OpenMP.cs
+++ b/TreeConverter/OpenMP/OpenMP.cs
@@ -2,9 +2,7 @@
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
 using System;
 using System.Collections.Generic;
-using System.Text;
 using PascalABCCompiler.TreeRealization;
-using System.Collections;
 
 namespace PascalABCCompiler.TreeConverter
 {
@@ -104,7 +102,7 @@ namespace PascalABCCompiler.TreeConverter
         public List<var_definition_node> current_var_defs;
         public Stack<code_block> block_stack;
         public statement_node_stack cycle_stack;
-        public Hashtable current_member_decls;
+        public Dictionary<SyntaxTree.declaration, definition_node> current_member_decls;
         public common_function_node_stack function_node_stack;
         public SymbolInfo current_last_created_function;
         public bool SemanticRulesThrowErrorWithoutSave;
@@ -122,7 +120,7 @@ namespace PascalABCCompiler.TreeConverter
             cycle_stack = syntax_tree_visitor.context.CyclesStack;
             syntax_tree_visitor.context.CyclesStack = new statement_node_stack();
             current_member_decls = syntax_tree_visitor.context.member_decls;
-            syntax_tree_visitor.context.member_decls = new Hashtable();
+            syntax_tree_visitor.context.member_decls = new Dictionary<SyntaxTree.declaration, definition_node>();
             function_node_stack = syntax_tree_visitor.context.func_stack;
             syntax_tree_visitor.context.func_stack = new common_function_node_stack();
             current_last_created_function = syntax_tree_visitor.context.last_created_function;

--- a/TreeConverter/TreeConversion/InitializationDataForConverting.cs
+++ b/TreeConverter/TreeConversion/InitializationDataForConverting.cs
@@ -12,7 +12,7 @@ namespace PascalABCCompiler.TreeConverter.TreeConversion
     {
         public readonly Errors.SyntaxError parserError;
 
-        public readonly Hashtable badNodes;
+        public readonly HashSet<SyntaxTree.syntax_tree_node> badNodes;
 
         public readonly TreeRealization.unit_node_list usedUnits;
 
@@ -37,7 +37,7 @@ namespace PascalABCCompiler.TreeConverter.TreeConversion
         public InitializationDataForCompilingInterface(
             
             Errors.SyntaxError parserError, 
-            Hashtable badNodes, 
+            HashSet<SyntaxTree.syntax_tree_node> badNodes, 
             TreeRealization.unit_node_list usedUnits, 
             TreeRealization.using_namespace_list interfaceNamespaces, 
             compilation_unit syntaxUnit, 
@@ -78,7 +78,7 @@ namespace PascalABCCompiler.TreeConverter.TreeConversion
         public InitializationDataForCompilingImplementation(
             
             Errors.SyntaxError parserError, 
-            Hashtable badNodes, 
+            HashSet<SyntaxTree.syntax_tree_node> badNodes, 
             TreeRealization.unit_node_list usedUnits, 
             TreeRealization.using_namespace_list interfaceNamespaces, 
             TreeRealization.using_namespace_list implementationNamespaces,

--- a/TreeConverter/TreeConversion/compilation_context.cs
+++ b/TreeConverter/TreeConversion/compilation_context.cs
@@ -4,7 +4,6 @@
 using PascalABCCompiler.CoreUtils;
 using PascalABCCompiler.TreeRealization;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -36,7 +35,7 @@ namespace PascalABCCompiler.TreeConverter
     	public statement_node_stack cycles_stack;
         public int num_of_for_cycles;
         public SemanticTree.field_access_level _fal;
-        public System.Collections.Hashtable member_decls;
+        public Dictionary<SyntaxTree.declaration, definition_node> member_decls;
         public List<common_type_node> types_predefined;
         public Stack<common_type_node> type_stack; // Для вложенных типов
         public statement_list_stack stlist_stack;
@@ -127,7 +126,7 @@ namespace PascalABCCompiler.TreeConverter
     	    _cycles_stack = new statement_node_stack();
             _num_of_for_cycles = 0;
             _fal = SemanticTree.field_access_level.fal_private;
-            member_decls = new Hashtable();
+            member_decls = new Dictionary<SyntaxTree.declaration, definition_node>();
             _types_predefined = new List<common_type_node>();
             syntax_tree_visitor.ret.return_value(null);
             // _type_stack = new Stack<common_type_node>(); 
@@ -250,7 +249,7 @@ namespace PascalABCCompiler.TreeConverter
         private static compilation_context _instance;
 
         private Dictionary<common_namespace_node, Dictionary<string, template_class>> compiled_tc_cache = new Dictionary<common_namespace_node, Dictionary<string, template_class>>();
-        internal System.Collections.Hashtable member_decls = new System.Collections.Hashtable();
+        internal Dictionary<SyntaxTree.declaration, definition_node> member_decls = new Dictionary<SyntaxTree.declaration, definition_node>();
         internal bool namespace_converted = false;
 
         public compilation_context(convertion_data_and_alghoritms convertion_data_and_alghoritms, syntax_tree_visitor syntax_tree_visitor)
@@ -430,12 +429,16 @@ namespace PascalABCCompiler.TreeConverter
         
         public common_function_node get_method_to_realize(SyntaxTree.declaration dc)
         {
-        	return member_decls[dc] as common_function_node;
+            member_decls.TryGetValue(dc, out var result);
+
+            return result as common_function_node;
         }
 
         public common_type_node get_type_to_realize(SyntaxTree.declaration dc)
         {
-            return member_decls[dc] as common_type_node;
+            member_decls.TryGetValue(dc, out var result);
+
+            return result as common_type_node;
         }
 
         public void add_method_header(SyntaxTree.declaration dc, definition_node dn)

--- a/TreeConverter/TreeConversion/convertion_data_and_alghoritms.cs
+++ b/TreeConverter/TreeConversion/convertion_data_and_alghoritms.cs
@@ -126,7 +126,7 @@ namespace PascalABCCompiler.TreeConverter
                 _parser_error = value;
             }
 		}
-        public System.Collections.Hashtable bad_nodes_in_syntax_tree;
+        public HashSet<SyntaxTree.syntax_tree_node> bad_nodes_in_syntax_tree;
 
 		public SymbolTable.TreeConverterSymbolTable symbol_table
 		{
@@ -3330,7 +3330,7 @@ namespace PascalABCCompiler.TreeConverter
 			{
 				return;
 			}
-			if (bad_nodes_in_syntax_tree[tn]!=null)
+			if ( bad_nodes_in_syntax_tree.Contains(tn) )
 			{
 				AddError(new ParserError(_parser_error,_stv.get_location(tn)));
 			}

--- a/TreeConverter/TreeConversion/syntax_tree_visitor.cs
+++ b/TreeConverter/TreeConversion/syntax_tree_visitor.cs
@@ -717,7 +717,7 @@ namespace PascalABCCompiler.TreeConverter
                 convertion_data_and_alghoritms.parser_error = value;
             }
         }
-        public System.Collections.Hashtable BadNodesInSyntaxTree
+        public HashSet<SyntaxTree.syntax_tree_node> BadNodesInSyntaxTree
         {
             get
             {
@@ -19741,8 +19741,8 @@ namespace PascalABCCompiler.TreeConverter
             SemanticTree.field_access_level curr_fal = context.get_field_access_level();
             List<var_definition_node> current_var_defs = context.var_defs;
             context.var_defs = new List<var_definition_node>();
-            Hashtable current_member_decls = context.member_decls;
-            context.member_decls = new Hashtable();
+            Dictionary<SyntaxTree.declaration, definition_node> current_member_decls = context.member_decls;
+            context.member_decls = new Dictionary<declaration, definition_node>();
             //подменяем using-список 
             using_namespace_list current_using_list = new using_namespace_list();
             foreach (using_namespace un in using_list)

--- a/TreeConverter/TreeRealization/generics.cs
+++ b/TreeConverter/TreeRealization/generics.cs
@@ -232,14 +232,18 @@ namespace PascalABCCompiler.TreeRealization
         public static List<SemanticTree.IGenericFunctionInstance> all_function_instances =
             new List<SemanticTree.IGenericFunctionInstance>();
 
-        public static Hashtable generic_instances = new Hashtable();
+        public static Dictionary<definition_node, object> generic_instances =
+            new Dictionary<definition_node, object>();
 
         public static syntax_tree_visitor visitor;
 
         public static List<generic_type_instance_info> get_type_instances(type_node original_generic_type)
         {
-            List<generic_type_instance_info> instances = generic_instances[original_generic_type] as List<generic_type_instance_info>;
-            if (instances == null)
+            List<generic_type_instance_info> instances;
+            
+            if ( generic_instances.TryGetValue(original_generic_type, out var temp) )
+                instances = (List<generic_type_instance_info>)temp;
+            else
             {
                 instances = new List<generic_type_instance_info>();
                 generic_instances.Add(original_generic_type, instances);
@@ -249,14 +253,17 @@ namespace PascalABCCompiler.TreeRealization
 
         public static void remove_type_instances(type_node original_generic_type)
         {
-            if (generic_instances[original_generic_type] != null)
+            if (generic_instances.ContainsKey(original_generic_type))
                 generic_instances.Remove(original_generic_type);
         }
 
         public static List<generic_function_instance_info> get_function_instances(function_node original_generic_function)
         {
-            List<generic_function_instance_info> instances = generic_instances[original_generic_function] as List<generic_function_instance_info>;
-            if (instances == null)
+            List<generic_function_instance_info> instances;
+            
+            if ( generic_instances.TryGetValue(original_generic_function, out var temp) )
+                instances = (List<generic_function_instance_info>)temp;
+            else
             {
                 instances = new List<generic_function_instance_info>();
                 generic_instances.Add(original_generic_function, instances);


### PR DESCRIPTION
В некоторых местах наиболее общим типом значения оказался `object`