### PR TITLE
Рефакторинг семантики

### DIFF
--- a/NETGenerator/NETGenerator.cs
+++ b/NETGenerator/NETGenerator.cs
@@ -398,11 +398,11 @@ namespace PascalABCCompiler.NETGenerator
             }
         }
 
-        private ICommonFunctionNode GetGenericFunctionContainer(ITypeNode tn)
+        private IFunctionNode GetGenericFunctionContainer(ITypeNode tn)
         {
-            if (tn.common_generic_function_container != null)
+            if (tn.generic_function_container != null)
             {
-                return tn.common_generic_function_container;
+                return tn.generic_function_container;
             }
             if (tn.type_special_kind == type_special_kind.typed_file)
             {
@@ -426,7 +426,7 @@ namespace PascalABCCompiler.NETGenerator
             {
                 foreach (ITypeNode par in igti.generic_parameters)
                 {
-                    ICommonFunctionNode rez = GetGenericFunctionContainer(par);
+                    IFunctionNode rez = GetGenericFunctionContainer(par);
                     if (rez != null)
                     {
                         return rez;
@@ -2535,7 +2535,7 @@ namespace PascalABCCompiler.NETGenerator
                     TypeInfo tinfo = helper.GetTypeReference(itn);
                     if (tinfo == null)
                     {
-                        AddTypeInstanceToFunction(GetGenericFunctionContainer(value), igtn);
+                        AddTypeInstanceToFunction((ICommonFunctionNode)GetGenericFunctionContainer(value), igtn);
                         return;
                     }
                     iparams.Add(tinfo.tp);

--- a/SemanticTree/SemanticTree.cs
+++ b/SemanticTree/SemanticTree.cs
@@ -242,12 +242,12 @@ namespace PascalABCCompiler.SemanticTree
         }
 
         //Описание generic-типа, содержащее данный параметр
-        ICommonTypeNode generic_type_container
+        ITypeNode generic_type_container
         {
             get;
         }
 
-        ICommonFunctionNode common_generic_function_container
+        IFunctionNode generic_function_container
         {
             get;
         }

--- a/TreeConverter/TreeRealization/types.cs
+++ b/TreeConverter/TreeRealization/types.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Ivan Bondarev, Stanislav Mikhalkovich (for details please see \doc\copyright.txt)
 // This code is distributed under the GNU LGPL (for details please see \doc\license.txt)
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
@@ -143,7 +142,7 @@ namespace PascalABCCompiler.TreeRealization
             }
         }
         
-        public virtual SemanticTree.ICommonTypeNode generic_type_container
+        public virtual SemanticTree.ITypeNode generic_type_container
         {
             get
             {
@@ -165,11 +164,11 @@ namespace PascalABCCompiler.TreeRealization
             }
         }
 
-        SemanticTree.ICommonFunctionNode SemanticTree.ITypeNode.common_generic_function_container
+        SemanticTree.IFunctionNode SemanticTree.ITypeNode.generic_function_container
         {
             get
             {
-                return generic_function_container as SemanticTree.ICommonFunctionNode;
+                return generic_function_container;
             }
         }
 
@@ -1434,7 +1433,7 @@ namespace PascalABCCompiler.TreeRealization
 
         private SemanticTree.ICommonTypeNode _generic_type_container = null;
 
-        public override SemanticTree.ICommonTypeNode generic_type_container
+        public override SemanticTree.ITypeNode generic_type_container
         {
             get
             {
@@ -1442,7 +1441,7 @@ namespace PascalABCCompiler.TreeRealization
             }
             set
             {
-                _generic_type_container = value;
+                _generic_type_container = (SemanticTree.ICommonTypeNode)value;
             }
         }
 
@@ -1465,7 +1464,7 @@ namespace PascalABCCompiler.TreeRealization
             {
                 if (_generic_type_container != null)
                 {
-                    return generic_type_container.generic_params.IndexOf(this);
+                    return _generic_type_container.generic_params.IndexOf(this);
                 }
                 else
                 {
@@ -3021,6 +3020,22 @@ namespace PascalABCCompiler.TreeRealization
                     return null;
                 }
                 return compiled_function_node.get_compiled_method(_compiled_type.DeclaringMethod as System.Reflection.MethodInfo);
+            }
+        }
+
+        public override SemanticTree.ITypeNode generic_type_container
+        {
+            get
+            {
+                if (!_compiled_type.IsGenericParameter || _compiled_type.DeclaringMethod == null)
+                {
+                    return null;
+                }
+                return get_type_node(_compiled_type.DeclaringType);
+            }
+            set
+            {
+                throw new NotSupportedException();
             }
         }
 


### PR DESCRIPTION
Интерфейс `SemanticTree.ITypeNode` содержал ссылки на `ICommonTypeNode` и `ICommonFunctionNode`, что нарушало уровень абстракции и не позволяло получить аналогичную информацию для типов из других сборок, что стало актуально при миграции на Mono.Cecil

Данный PR выравнивает уровень абстракции